### PR TITLE
Split CT into three steps

### DIFF
--- a/.github/workflows/javascript-test.yml
+++ b/.github/workflows/javascript-test.yml
@@ -3,7 +3,7 @@ name: Continuous testing
 on: [pull_request]
 
 jobs:
-  test:
+  install:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -13,9 +13,56 @@ jobs:
           node-version: 18
       - name: Install dependencies
         run: yarn install --frozen-lockfile
-      - name: Run lint
-        run: yarn lint
-      - name: Build the project
-        run: yarn build
-      - name: Run tests
-        run: yarn test
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: deps
+          path: node_modules
+
+  lint:
+    needs: install
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use node 18
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Get dependencies
+        uses: actions/download-artifact@v2
+        with:
+          name: deps
+          path: node_modules
+      - run: yarn run lint
+      
+  build:
+    needs: install
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use node 18
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Get dependencies
+        uses: actions/download-artifact@v2
+        with:
+          name: deps
+          path: node_modules
+      - run: yarn run build
+
+  test:
+    needs: install
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use node 18
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Get dependencies
+        uses: actions/download-artifact@v2
+        with:
+          name: deps
+          path: node_modules
+      - run: yarn run test

--- a/.github/workflows/javascript-test.yml
+++ b/.github/workflows/javascript-test.yml
@@ -3,20 +3,7 @@ name: Continuous testing
 on: [pull_request]
 
 jobs:
-  install:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Use node 18
-        uses: actions/setup-node@v3
-        with:
-          node-version: 18
-      - uses: c-hive/gha-yarn-cache@v2
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile
-
   lint:
-    needs: install
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -30,7 +17,6 @@ jobs:
       - run: yarn run lint
 
   build:
-    needs: install
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -44,7 +30,6 @@ jobs:
       - run: yarn run build
 
   test:
-    needs: install
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/javascript-test.yml
+++ b/.github/workflows/javascript-test.yml
@@ -11,13 +11,9 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 18
+      - uses: c-hive/gha-yarn-cache@v2
       - name: Install dependencies
         run: yarn install --frozen-lockfile
-      - name: Upload artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: deps
-          path: node_modules
 
   lint:
     needs: install
@@ -28,13 +24,11 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 18
-      - name: Get dependencies
-        uses: actions/download-artifact@v2
-        with:
-          name: deps
-          path: node_modules
+      - uses: c-hive/gha-yarn-cache@v2
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
       - run: yarn run lint
-      
+
   build:
     needs: install
     runs-on: ubuntu-latest
@@ -44,11 +38,9 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 18
-      - name: Get dependencies
-        uses: actions/download-artifact@v2
-        with:
-          name: deps
-          path: node_modules
+      - uses: c-hive/gha-yarn-cache@v2
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
       - run: yarn run build
 
   test:
@@ -60,9 +52,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 18
-      - name: Get dependencies
-        uses: actions/download-artifact@v2
-        with:
-          name: deps
-          path: node_modules
+      - uses: c-hive/gha-yarn-cache@v2
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
       - run: yarn run test

--- a/README.md
+++ b/README.md
@@ -2,4 +2,6 @@
 
 [![GitHub Issue Sync](https://github.com/paritytech/review-bot/actions/workflows/github-issue-sync.yml/badge.svg)](https://github.com/paritytech/review-bot/actions/workflows/github-issue-sync.yml)
 
+[![Publish package to GitHub Packages](https://github.com/paritytech/review-bot/actions/workflows/publish.yml/badge.svg?branch=main)](https://github.com/paritytech/review-bot/actions/workflows/publish.yml)
+
 Have custom review rules for PRs with auto assignment.


### PR DESCRIPTION
Spliced the continuous testing step into three separated steps.

Added the yarn install as a needed step that downloads the dependencies (just to stop it from spamming three yarn installs at the same time).

Closes #7