### PR TITLE
updated linting to use latest version

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -6,14 +6,5 @@ const conf = getConfiguration({ typescript: tsConfParams });
 
 const tsConfOverride = getTypescriptOverride(tsConfParams);
 conf.overrides.push(tsConfOverride);
-module.exports = {
-  ...conf,
-  overrides: [
-    ...conf.overrides,
-    {
-      ...tsConfOverride,
-      files: "{*,**,**/*}.{ts,tsx}",
-      rules: { ...tsConfOverride.rules, "no-restricted-imports": "off" },
-    },
-  ],
-};
+
+module.exports = conf;

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/paritytech/review-bot#readme",
   "devDependencies": {
-    "@eng-automation/js-style": "^2.1.0",
+    "@eng-automation/js-style": "^2.2.0",
     "@octokit/webhooks-types": "^7.1.0",
     "@types/jest": "^29.5.3",
     "@vercel/ncc": "^0.36.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -329,10 +329,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@eng-automation/js-style@^2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@eng-automation/js-style/-/js-style-2.1.0.tgz#9f6b9ce911e65ef103ed03ed7c92dac06d5abe7f"
-  integrity sha512-jAMAE7SzIjVMNXkkNwuyJKEHcge47xXaIvg/z6K0pr9ImIp8ZcAoP/B5v58Zy5FOSyweNQISrnYVZjGfw7ZatQ==
+"@eng-automation/js-style@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@eng-automation/js-style/-/js-style-2.2.0.tgz#d7c21dd68e4f3b1886c522723e691866e206dd11"
+  integrity sha512-j1S6kRLkavv4X4azP8dIhiGTmHG/BkuOG01abVaJbAJJXsNYWyKFjoRQjywkBvF9i8sknDzql33iRr5jhArOYw==
   dependencies:
     "@typescript-eslint/eslint-plugin" "^5.59.1"
     "@typescript-eslint/parser" "^5.59.1"


### PR DESCRIPTION
This removes the need to disable `no-restricted-imports`