### PR TITLE
Created BASIC rule implementation

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,9 @@ inputs:
   repo-token:
     required: true
     description: The token to access the repo and the pull request data
+  team-token:
+    required: true
+    description: A GitHub Token with read:org access
   config-file:
     description: 'Location of the configuration file'
     required: false

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "fix": "eslint --fix '{src,test}/**/*'",
     "lint": "eslint '{src,test}/**/*'"
   },
+  "engines": {
+    "node": ">=18.0.0"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/paritytech/review-bot.git"

--- a/src/file/types.ts
+++ b/src/file/types.ts
@@ -3,7 +3,7 @@ enum Rules {
   Debug = "debug",
 }
 
-type Reviewers = { users?: string[]; teams?: string[] };
+export type Reviewers = { users?: string[]; teams?: string[] };
 
 export interface Rule {
   name: string;

--- a/src/file/types.ts
+++ b/src/file/types.ts
@@ -1,4 +1,4 @@
-enum Rules {
+export enum RuleTypes {
   Basic = "basic",
   Debug = "debug",
 }
@@ -12,12 +12,12 @@ export interface Rule {
 
 // TODO: Delete this once we add a second type of rule
 export interface DebugRule extends Rule {
-  type: Rules.Debug;
+  type: RuleTypes.Debug;
   size: number;
 }
 
 export interface BasicRule extends Rule, Reviewers {
-  type: Rules.Basic;
+  type: RuleTypes.Basic;
   min_approvals: number;
 }
 
@@ -26,8 +26,8 @@ export interface ConfigurationFile {
    * @see {@link Rules}
    */
   rules: (BasicRule | DebugRule)[];
-  preventReviewRequests: {
+  preventReviewRequests?: {
     teams?: string[];
-    users: string[];
+    users?: string[];
   };
 }

--- a/src/github/pullRequest.ts
+++ b/src/github/pullRequest.ts
@@ -14,6 +14,8 @@ export class PullRequestApi {
     this.number = pr.number;
   }
 
+  /** Cache of the list of files that have been modified by a PR */
+  private filesChanged: string[] = [];
   async getConfigFile(configFilePath: string): Promise<string> {
     const { data } = await this.api.rest.repos.getContent({
       owner: this.pr.base.repo.owner.login,
@@ -32,5 +34,14 @@ export class PullRequestApi {
     this.logger.debug(`File content is ${decryptedFile}`);
 
     return decryptedFile;
+  }
+
+  /** Returns an array with all the files that had been modified */
+  async listModifiedFiles(): Promise<string[]> {
+    if (this.filesChanged.length === 0) {
+      const { data } = await this.api.rest.pulls.listFiles({ ...this.repoInfo, pull_number: this.number });
+      this.filesChanged = data.map((f) => f.filename);
+    }
+    return this.filesChanged;
   }
 }

--- a/src/github/pullRequest.ts
+++ b/src/github/pullRequest.ts
@@ -1,4 +1,4 @@
-import { PullRequest } from "@octokit/webhooks-types";
+import { PullRequest, PullRequestReview } from "@octokit/webhooks-types";
 
 import { ActionLogger, GitHubClient } from "./types";
 
@@ -16,6 +16,9 @@ export class PullRequestApi {
 
   /** Cache of the list of files that have been modified by a PR */
   private filesChanged: string[] = [];
+  /** Cache for the list of logins that have approved the PR */
+  private usersThatApprovedThePr: string[] | null = null;
+
   async getConfigFile(configFilePath: string): Promise<string> {
     const { data } = await this.api.rest.repos.getContent({
       owner: this.pr.base.repo.owner.login,
@@ -43,5 +46,16 @@ export class PullRequestApi {
       this.filesChanged = data.map((f) => f.filename);
     }
     return this.filesChanged;
+  }
+
+  /** List all the approved reviews in a PR */
+  async listApprovedReviewsAuthors(): Promise<string[]> {
+    if (!this.usersThatApprovedThePr) {
+      const request = await this.api.rest.pulls.listReviews({ ...this.repoInfo, pull_number: this.number });
+      const reviews = request.data as PullRequestReview[];
+      const approvals = reviews.filter((review) => review.state === "approved");
+      this.usersThatApprovedThePr = approvals.map((approval) => approval.user.login);
+    }
+    return this.usersThatApprovedThePr;
   }
 }

--- a/src/github/pullRequest.ts
+++ b/src/github/pullRequest.ts
@@ -4,11 +4,15 @@ import { ActionLogger, GitHubClient } from "./types";
 
 /** API class that uses the default token to access the data from the pull request and the repository */
 export class PullRequestApi {
+  private readonly number: number;
   constructor(
     private readonly api: GitHubClient,
     private readonly pr: PullRequest,
     private readonly logger: ActionLogger,
-  ) {}
+    private readonly repoInfo: { repo: string; owner: string },
+  ) {
+    this.number = pr.number;
+  }
 
   async getConfigFile(configFilePath: string): Promise<string> {
     const { data } = await this.api.rest.repos.getContent({

--- a/src/github/teams.ts
+++ b/src/github/teams.ts
@@ -1,0 +1,33 @@
+import { getOctokit } from "@actions/github";
+
+import { ActionLogger, GitHubClient } from "./types";
+
+/**
+ * Interface for the acquisition of members of a team.
+ * As we may be using blockchain instead of GitHub teams, let's wrap the functionality inside a interface
+ */
+export interface TeamApi {
+  /** Returns all the GitHub account's logins which belong to a given team. */
+  getTeamMembers(teamName: string): Promise<string[]>;
+}
+
+/** 
+ * Implementation of the TeamApi interface using GitHub teams
+ * @see-also {@link TeamApi}
+ */
+export class GitHubTeamsApi implements TeamApi {
+  private readonly api: GitHubClient;
+
+  /**
+   * @param teamOrgToken GitHub token with read:org access. It is used to access the organization team members
+   * @param org Name of the organization the team will belong to. Should be available in context.repo.owner
+   */
+  constructor(teamOrgToken: string, private readonly org: string, private readonly logger: ActionLogger) {
+    this.api = getOctokit(teamOrgToken);
+  }
+
+  async getTeamMembers(teamName: string): Promise<string[]> {
+    const { data } = await this.api.rest.teams.listMembersInOrg({ org: this.org, team_slug: teamName });
+    return data.map((d) => d.login);
+  }
+}

--- a/src/github/teams.ts
+++ b/src/github/teams.ts
@@ -18,6 +18,9 @@ export interface TeamApi {
 export class GitHubTeamsApi implements TeamApi {
   private readonly api: GitHubClient;
 
+  /** Cache variable so we don't request the same information from GitHub in one run  */
+  private readonly teamsCache: Map<string, string[]> = new Map<string, string[]>();
+
   /**
    * @param teamOrgToken GitHub token with read:org access. It is used to access the organization team members
    * @param org Name of the organization the team will belong to. Should be available in context.repo.owner
@@ -27,6 +30,10 @@ export class GitHubTeamsApi implements TeamApi {
   }
 
   async getTeamMembers(teamName: string): Promise<string[]> {
+    // We first verify that this information hasn't been fetched yet
+    if (this.teamsCache.has(teamName)) {
+      return this.teamsCache.get(teamName) as string[];
+    }
     const { data } = await this.api.rest.teams.listMembersInOrg({ org: this.org, team_slug: teamName });
     return data.map((d) => d.login);
   }

--- a/src/github/teams.ts
+++ b/src/github/teams.ts
@@ -11,7 +11,7 @@ export interface TeamApi {
   getTeamMembers(teamName: string): Promise<string[]>;
 }
 
-/** 
+/**
  * Implementation of the TeamApi interface using GitHub teams
  * @see-also {@link TeamApi}
  */

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { Context } from "@actions/github/lib/context";
 import { PullRequest } from "@octokit/webhooks-types";
 
 import { PullRequestApi } from "./github/pullRequest";
+import { GitHubTeamsApi } from "./github/teams";
 import { ActionRunner } from "./runner";
 import { generateCoreLogger } from "./util";
 
@@ -11,6 +12,8 @@ export interface Inputs {
   configLocation: string;
   /** GitHub's action default secret */
   repoToken: string;
+  /** A custom access token with the read:org access */
+  teamApiToken: string;
 }
 
 const getRepo = (ctx: Context) => {
@@ -30,8 +33,9 @@ const getRepo = (ctx: Context) => {
 const getInputs = (): Inputs => {
   const configLocation = getInput("config-file");
   const repoToken = getInput("repo-token", { required: true });
+  const teamApiToken = getInput("team-token", { required: true });
 
-  return { configLocation, repoToken };
+  return { configLocation, repoToken, teamApiToken };
 };
 
 const repo = getRepo(context);
@@ -53,7 +57,11 @@ const api = new PullRequestApi(
   repo,
 );
 
-const runner = new ActionRunner(api, generateCoreLogger());
+const logger = generateCoreLogger();
+
+const teamApi = new GitHubTeamsApi(inputs.teamApiToken, repo.owner, logger);
+
+const runner = new ActionRunner(api, teamApi, logger);
 
 runner
   .runAction(inputs)

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,6 +50,7 @@ const api = new PullRequestApi(
   getOctokit(inputs.repoToken),
   context.payload.pull_request as PullRequest,
   generateCoreLogger(),
+  repo,
 );
 
 const runner = new ActionRunner(api, generateCoreLogger());

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -7,7 +7,7 @@ import { PullRequestApi } from "./github/pullRequest";
 import { TeamApi } from "./github/teams";
 import { ActionLogger } from "./github/types";
 
-type ReviewErrorData = {
+type ReviewReport = {
   /** The amount of missing reviews to fulfill the requirements */
   missingReviews: number;
   /** The users who would qualify to complete those reviews */
@@ -17,7 +17,7 @@ type ReviewErrorData = {
   /** If applicable, the users that should be requested to review */
   usersToRequest?: string[];
 };
-type ReviewError = [true] | [false, ReviewErrorData];
+type ReviewState = [true] | [false, ReviewReport];
 
 /** Action in charge of running the GitHub action */
 export class ActionRunner {
@@ -80,7 +80,7 @@ export class ActionRunner {
    * @returns a [bool, error data] tuple which evaluates if the condition (not the rule itself) has fulfilled the requirements
    * @see-also ReviewError
    */
-  async evaluateCondition(rule: { min_approvals: number } & Reviewers): Promise<ReviewError> {
+  async evaluateCondition(rule: { min_approvals: number } & Reviewers): Promise<ReviewState> {
     // This is a list of all the users that need to approve a PR
     const requiredUsers: string[] = [];
     // If team is set, we fetch the members of such team

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -48,6 +48,7 @@ export class ActionRunner {
       const files = await this.listFilesThatMatchRuleCondition(rule);
       // We check if there are any matches
       if (files.length === 0) {
+        this.logger.debug(`Skipping rule ${rule.name} as no condition matched`);
         // If there are no matches, we simply skip the check
         continue;
       }

--- a/src/test/runner/basicRule.test.ts
+++ b/src/test/runner/basicRule.test.ts
@@ -5,17 +5,19 @@ import { mock, MockProxy } from "jest-mock-extended";
 
 import { BasicRule } from "../../file/types";
 import { PullRequestApi } from "../../github/pullRequest";
+import { TeamApi } from "../../github/teams";
 import { ActionRunner } from "../../runner";
 import { TestLogger } from "../logger";
 
 describe("Basic rule parsing", () => {
   let api: MockProxy<PullRequestApi>;
   let runner: ActionRunner;
+  let teamsApi: MockProxy<TeamApi>;
   let logger: TestLogger;
   beforeEach(() => {
     logger = new TestLogger();
     api = mock<PullRequestApi>();
-    runner = new ActionRunner(api, logger);
+    runner = new ActionRunner(api, teamsApi, logger);
   });
   test("should get minimal config", async () => {
     api.getConfigFile.mockResolvedValue(`

--- a/src/test/runner/conditions.test.ts
+++ b/src/test/runner/conditions.test.ts
@@ -1,0 +1,85 @@
+import { mock, MockProxy } from "jest-mock-extended";
+
+import { PullRequestApi } from "../../github/pullRequest";
+import { TeamApi } from "../../github/teams";
+import { ActionRunner } from "../../runner";
+import { TestLogger } from "../logger";
+
+describe("evaluateCondition tests", () => {
+  let api: MockProxy<PullRequestApi>;
+  let teamsApi: MockProxy<TeamApi>;
+  let runner: ActionRunner;
+  let logger: TestLogger;
+  beforeEach(() => {
+    logger = new TestLogger();
+    api = mock<PullRequestApi>();
+    teamsApi = mock<TeamApi>();
+    runner = new ActionRunner(api, teamsApi, logger);
+  });
+
+  test("should throw if no teams or users were set", async () => {
+    await expect(runner.evaluateCondition({ min_approvals: 99 })).rejects.toThrowError(
+      "Teams and Users field are not set for rule.",
+    );
+  });
+
+  describe("users tests", () => {
+    const users = ["user-1", "user-2", "user-3"];
+    beforeEach(() => {
+      api.listApprovedReviewsAuthors.mockResolvedValue(users);
+    });
+
+    test("should pass if required users approved the PR", async () => {
+      const [result] = await runner.evaluateCondition({ min_approvals: 1, users: [users[0]] });
+      expect(result).toBeTruthy();
+    });
+
+    test("should pass if required amount of users approved the PR", async () => {
+      const [result] = await runner.evaluateCondition({ min_approvals: 2, users: [users[0], users[users.length - 1]] });
+      expect(result).toBeTruthy();
+    });
+
+    test("should fail if not all required users approved the PR", async () => {
+      const newUser = "missing-user";
+      const [result, missingData] = await runner.evaluateCondition({ min_approvals: 2, users: [users[0], newUser] });
+      expect(result).toBeFalsy();
+      expect(missingData?.missingUsers).toContainEqual(newUser);
+      expect(missingData?.missingUsers).not.toContainEqual(users[0]);
+      expect(missingData?.usersToRequest).toContainEqual(newUser);
+      expect(missingData?.usersToRequest).not.toContainEqual(users[0]);
+      expect(missingData?.missingReviews).toBe(1);
+    });
+  });
+
+  describe("teams tests", () => {
+    const users = ["user-1", "user-2", "user-3"];
+    const team = "team-example";
+    beforeEach(() => {
+      api.listApprovedReviewsAuthors.mockResolvedValue(users);
+    });
+
+    test("should pass if required users approved the PR", async () => {
+      teamsApi.getTeamMembers.mockResolvedValue(users);
+      const [result] = await runner.evaluateCondition({ min_approvals: 1, teams: [team] });
+      expect(result).toBeTruthy();
+    });
+
+    test("should pass if required amount of users approved the PR", async () => {
+      teamsApi.getTeamMembers.mockResolvedValue(users);
+      const [result] = await runner.evaluateCondition({ min_approvals: 2, teams: [team] });
+      expect(result).toBeTruthy();
+    });
+
+    test("should fail if not enough members of a team approved the PR", async () => {
+      api.listApprovedReviewsAuthors.mockResolvedValue([users[0]]);
+      teamsApi.getTeamMembers.mockResolvedValue(users);
+      const [result, missingData] = await runner.evaluateCondition({ min_approvals: 2, teams: [team] });
+      expect(result).toBeFalsy();
+      expect(missingData?.missingUsers).toEqual(users.slice(1));
+      expect(missingData?.missingUsers).not.toContainEqual(users[0]);
+      expect(missingData?.usersToRequest).toBeUndefined();
+      expect(missingData?.teamsToRequest).toContainEqual(team);
+      expect(missingData?.missingReviews).toBe(1);
+    });
+  });
+});

--- a/src/test/runner/config.test.ts
+++ b/src/test/runner/config.test.ts
@@ -80,7 +80,7 @@ describe("Config Parsing", () => {
             - team-b
         `);
       const config = await runner.getConfigFile("");
-      expect(config.preventReviewRequests.teams).toEqual(["team-a", "team-b"]);
+      expect(config.preventReviewRequests?.teams).toEqual(["team-a", "team-b"]);
     });
 
     test("should get users", async () => {
@@ -102,7 +102,7 @@ describe("Config Parsing", () => {
             - user-b
         `);
       const config = await runner.getConfigFile("");
-      expect(config.preventReviewRequests.users).toEqual(["user-a", "user-b"]);
+      expect(config.preventReviewRequests?.users).toEqual(["user-a", "user-b"]);
     });
 
     test("should fail with both users and teams", async () => {

--- a/src/test/runner/config.test.ts
+++ b/src/test/runner/config.test.ts
@@ -4,17 +4,19 @@
 import { mock, MockProxy } from "jest-mock-extended";
 
 import { PullRequestApi } from "../../github/pullRequest";
+import { TeamApi } from "../../github/teams";
 import { ActionRunner } from "../../runner";
 import { TestLogger } from "../logger";
 
 describe("Config Parsing", () => {
   let api: MockProxy<PullRequestApi>;
+  let teamsApi: MockProxy<TeamApi>;
   let runner: ActionRunner;
   let logger: TestLogger;
   beforeEach(() => {
     logger = new TestLogger();
     api = mock<PullRequestApi>();
-    runner = new ActionRunner(api, logger);
+    runner = new ActionRunner(api, teamsApi, logger);
   });
   test("should get minimal config", async () => {
     api.getConfigFile.mockResolvedValue(`

--- a/src/test/runner/runner.test.ts
+++ b/src/test/runner/runner.test.ts
@@ -1,0 +1,65 @@
+import { mock, MockProxy } from "jest-mock-extended";
+
+import { ConfigurationFile, Rule, RuleTypes } from "../../file/types";
+import { PullRequestApi } from "../../github/pullRequest";
+import { TeamApi } from "../../github/teams";
+import { ActionRunner } from "../../runner";
+import { TestLogger } from "../logger";
+
+describe("Shared validations", () => {
+  let api: MockProxy<PullRequestApi>;
+  let teamsApi: MockProxy<TeamApi>;
+  let runner: ActionRunner;
+  let logger: TestLogger;
+  beforeEach(() => {
+    logger = new TestLogger();
+    api = mock<PullRequestApi>();
+    runner = new ActionRunner(api, teamsApi, logger);
+  });
+
+  test("validatePullRequest should return true if no rule matches any files", async () => {
+    const config: ConfigurationFile = {
+      rules: [
+        { name: "Rule 1", type: RuleTypes.Basic, condition: { include: ["src"] }, min_approvals: 1 },
+        { name: "Rule 2", type: RuleTypes.Basic, condition: { include: ["README.md"] }, min_approvals: 99 },
+      ],
+    };
+    api.listModifiedFiles.mockResolvedValue([".github/workflows/review-bot.yml", "LICENSE"]);
+    const evaluation = await runner.validatePullRequest(config);
+    expect(evaluation).toBeTruthy();
+  });
+
+  describe("listFilesThatMatchRuleCondition tests", () => {
+    test("should get values that match the condition", async () => {
+      const mockRule = { condition: { include: ["src"] } };
+      api.listModifiedFiles.mockResolvedValue(["src/index.ts", "README.md"]);
+      const result = await runner.listFilesThatMatchRuleCondition(mockRule as Rule);
+      expect(result).toContainEqual("src/index.ts");
+    });
+
+    test("should return only one file even if more than one rule matches it", async () => {
+      const mockRule = { condition: { include: ["\\.ts", "src"] } };
+      api.listModifiedFiles.mockResolvedValue(["src/index.ts"]);
+      const result = await runner.listFilesThatMatchRuleCondition(mockRule as Rule);
+      expect(result).toEqual(["src/index.ts"]);
+    });
+
+    test("should include all the files with a global value", async () => {
+      const mockRule = { condition: { include: [".+", "src"] } };
+      const listedFiles = ["src/index.ts", ".github/workflows/review-bot.yml", "yarn-error.log"];
+      api.listModifiedFiles.mockResolvedValue(listedFiles);
+      const result = await runner.listFilesThatMatchRuleCondition(mockRule as Rule);
+      expect(result).toEqual(listedFiles);
+    });
+
+    test("should exclude files if they are captured by the include condition", async () => {
+      const mockRule = { condition: { include: [".+"], exclude: ["\\.yml"] } };
+      const listedFiles = ["src/index.ts", ".github/workflows/review-bot.yml", "yarn-error.log"];
+      api.listModifiedFiles.mockResolvedValue(listedFiles);
+      const result = await runner.listFilesThatMatchRuleCondition(mockRule as Rule);
+      expect(result).toContainEqual("src/index.ts");
+      expect(result).toContainEqual("yarn-error.log");
+      expect(result).not.toContain(".github/workflows/review-bot.yml");
+    });
+  });
+});


### PR DESCRIPTION
## Basic rule
Implemented the functionality of the basic rule.

Because every rule ends up being simplified into:
```typescript
{
  min_approvals: number;
  teams?: string[];
  users?: string[];
}
```

I created a basic logic that evaluates that. After this, we can use the result of those smaller conditions to evaluate the more complex rules.

I added a lot of tests and tried to do as many comments to explain the logic as possible.

## Teams API
Created class which handles the teams token and obtains the team members of a team.

This class is small but handles the token used for such authentication and separates the concern. 

If we decide to replace GitHub teams for on-chain data (like mentioned in paritytech/opstooling#245) this would let us to simply switch the implementation with minimal alterations.

Closes #22 and closes #9