### PR TITLE
Sub shape migration

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@actions/github": "^5.1.1",
     "@eng-automation/js": "^0.0.22",
     "joi": "^17.9.2",
+    "subshape": "^0.14.0",
     "yaml": "^2.3.1"
   }
 }

--- a/src/file/validator.ts
+++ b/src/file/validator.ts
@@ -27,8 +27,6 @@ const $generalSchema = $.object(
   $.optionalField("preventReviewRequests", $.object($reviewersObj)),
 );
 
-type ConfigFile = $.Output<typeof $generalSchema>;
-
 /** Basic rule schema
  * This rule is quite simple as it only has the min_approvals field and the required reviewers
  */
@@ -48,9 +46,16 @@ export const validateConfig = (config: ConfigurationFile): ConfigurationFile | n
 
   for (const rule of config.rules) {
     const { name, type } = rule;
-    const message = `Configuration for rule '${rule.name}' is invalid`;
     if (type === "basic") {
       $.assert($basicRuleSchema, rule);
+      if (!rule.min_approvals) {
+        // TODO: Wait for https://github.com/paritytech/subshape/issues/173 and then implement it
+        rule.min_approvals = 1;
+      }
+      // TODO: Request an OR implementation
+      if (!rule.teams && !rule.users) {
+        throw new Error(`Users and/or teams must be set up! Problem found in rule ${rule.name}`);
+      }
     } else if (type === "debug") {
       $.assert($ruleSchema, rule);
     } else {

--- a/src/file/validator.ts
+++ b/src/file/validator.ts
@@ -15,8 +15,7 @@ const $reviewersObj = $.object($.optionalField("users", $.array($.str)), $.optio
 const $ruleSchema = $.object(
   $.field("name", $.str),
   $.field("condition", $.object($.field("include", $.array($.str)), $.optionalField("exclude", $.array($.str)))),
-  // TODO: Convert this into one of the literal types ("basic" | "and" | "andOr" | "xor")
-  $.field("type", $.str),
+  $.field("type", $.literalUnion(["basic", "debug"])),
 );
 
 /** General Configuration schema.

--- a/src/file/validator.ts
+++ b/src/file/validator.ts
@@ -24,7 +24,7 @@ const $ruleSchema = $.object(
  */
 const $generalSchema = $.object(
   $.field("rules", $.array($ruleSchema)),
-  $.field("preventReviewRequests", $.object($reviewersObj)),
+  $.optionalField("preventReviewRequests", $.object($reviewersObj)),
 );
 
 type ConfigFile = $.Output<typeof $generalSchema>;
@@ -32,7 +32,7 @@ type ConfigFile = $.Output<typeof $generalSchema>;
 /** Basic rule schema
  * This rule is quite simple as it only has the min_approvals field and the required reviewers
  */
-const $basicRuleSchema = $.object($.field("min_approvals", $.i8), $reviewersObj, $ruleSchema);
+const $basicRuleSchema = $.object($.optionalField("min_approvals", $.i8), $reviewersObj, $ruleSchema);
 
 /**
  * Evaluates a config thoroughly. If there is a problem with it, it will throw.
@@ -42,7 +42,7 @@ const $basicRuleSchema = $.object($.field("min_approvals", $.i8), $reviewersObj,
  * @param config The configuration object to be validated. Usually parsed directly from a yaml or json
  * @returns The configuration file post validation, or it throws an error.
  */
-export const validateConfig = (config: ConfigFile): ConfigurationFile | never => {
+export const validateConfig = (config: ConfigurationFile): ConfigurationFile | never => {
   // In theory this will throw when it fails the assertion
   $.assert($generalSchema, config);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3469,6 +3469,11 @@ strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
+subshape@^0.14.0:
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/subshape/-/subshape-0.14.0.tgz#6a9636f9a1cb8ec57022bcd09a14d4b42a56b3e5"
+  integrity sha512-Ijl2meay3TeDb6OuDf2prE6zPpK2y+nu6rvBpc6gpC+BNAJhOyT9AE/bFgufmBvQ+/xA07ZqZO4/UawT1sde6A==
+
 supports-color@^5.3.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"


### PR DESCRIPTION
Installed [subShape](https://github.com/paritytech/subshape) and migrated the code to use the library.

This resolves #24 

### Todo:
- [ ] Make the subShape generated type `ConfigFile` match the interface `ConfigurationFile`.
- [ ] Implement an XOR logic in the reviewers object
- [ ] Implement a literal type for the `type` field in the rule.