### PR TITLE
Added status checks

### DIFF
--- a/.github/workflows/review-bot.yml
+++ b/.github/workflows/review-bot.yml
@@ -12,6 +12,7 @@ on:
 
 permissions:
   contents: read
+  checks: write
 
 jobs:
   review-approvals:

--- a/src/github/pullRequest.ts
+++ b/src/github/pullRequest.ts
@@ -117,6 +117,13 @@ export class PullRequestApi {
       details_url: this.detailsUrl,
       head_sha: this.pr.head.sha,
       name: "review-bot",
+      output: {
+        title: "Review analysis results",
+        summary: `This summary was **generated** at ${new Date().getUTCDate()}\nFind details [here](${
+          this.detailsUrl
+        })`,
+        text: `This _text_ was **generated** at ${new Date().getUTCDate()}`,
+      },
     });
   }
 }

--- a/src/github/pullRequest.ts
+++ b/src/github/pullRequest.ts
@@ -115,6 +115,8 @@ export class PullRequestApi {
       external_id: "review-bot",
       conclusion,
       details_url: this.detailsUrl,
+      head_sha: this.pr.head.sha,
+      name: "review-bot",
     });
   }
 }

--- a/src/github/pullRequest.ts
+++ b/src/github/pullRequest.ts
@@ -111,7 +111,6 @@ export class PullRequestApi {
       owner: this.repoInfo.owner,
       repo: this.repoInfo.repo,
       external_id: "review-bot",
-      details_url: this.detailsUrl,
       head_sha: this.pr.head.sha,
       name: "review-bot",
     };

--- a/src/github/pullRequest.ts
+++ b/src/github/pullRequest.ts
@@ -1,3 +1,4 @@
+import { summary } from "@actions/core";
 import { PullRequest, PullRequestReview } from "@octokit/webhooks-types";
 
 import { caseInsensitiveEqual } from "../util";
@@ -135,6 +136,13 @@ export class PullRequestApi {
     this.logger.debug("Did not find any matching status check. Creating a new one");
 
     const check = await this.api.rest.checks.create(checkData);
+
+    // We publish it in the action summary
+    await summary
+      .addHeading(checkResult.output.title)
+      .addLink("Find the result here", check.data.html_url ?? "")
+      .addRaw(checkResult.output.text)
+      .write();
 
     this.logger.debug(JSON.stringify(check.data));
   }

--- a/src/github/pullRequest.ts
+++ b/src/github/pullRequest.ts
@@ -139,6 +139,7 @@ export class PullRequestApi {
     // We publish it in the action summary
     await summary
       .addHeading(checkResult.output.title)
+      // We redirect to the check as it can changed if it is triggered again
       .addLink("Find the result here", check.data.html_url ?? "")
       .addRaw(checkResult.output.text)
       .write();

--- a/src/github/pullRequest.ts
+++ b/src/github/pullRequest.ts
@@ -106,7 +106,7 @@ export class PullRequestApi {
     return this.pr.user.login;
   }
 
-  async generateCheckRun(conclusion: ActionConclussion): Promise<void> {
+  async generateCheckRun(conclusion: ActionConclussion, missingReviews?: number): Promise<void> {
     // await this.api.rest.checks.listSuitesForRef
 
     await this.api.rest.checks.create({
@@ -118,11 +118,11 @@ export class PullRequestApi {
       head_sha: this.pr.head.sha,
       name: "review-bot",
       output: {
-        title: "Review analysis results",
-        summary: `This summary was **generated** at ${new Date().getUTCDate()}\nFind details [here](${
+        title: missingReviews ? `Missing ${missingReviews} reviews` : "PR fulfilled required approvals",
+        summary: `This summary was **generated** at ${new Date().toUTCString()}\nFind details [here](${
           this.detailsUrl
         })`,
-        text: `This _text_ was **generated** at ${new Date().getUTCDate()}`,
+        text: `This _text_ was **generated** at ${new Date().toUTCString()}`,
       },
     });
   }

--- a/src/github/pullRequest.ts
+++ b/src/github/pullRequest.ts
@@ -3,6 +3,8 @@ import { PullRequest, PullRequestReview } from "@octokit/webhooks-types";
 import { caseInsensitiveEqual } from "../util";
 import { ActionLogger, GitHubClient } from "./types";
 
+type ActionConclussion = "action_required" | "failure" | "success";
+
 /** API class that uses the default token to access the data from the pull request and the repository */
 export class PullRequestApi {
   private readonly number: number;
@@ -11,6 +13,7 @@ export class PullRequestApi {
     private readonly pr: PullRequest,
     private readonly logger: ActionLogger,
     private readonly repoInfo: { repo: string; owner: string },
+    private readonly detailsUrl: string,
   ) {
     this.number = pr.number;
   }
@@ -101,5 +104,17 @@ export class PullRequestApi {
   /** Returns the login of the PR's author */
   getAuthor(): string {
     return this.pr.user.login;
+  }
+
+  async generateCheckRun(conclusion: ActionConclussion): Promise<void> {
+    // await this.api.rest.checks.listSuitesForRef
+
+    await this.api.rest.checks.create({
+      owner: this.repoInfo.owner,
+      repo: this.repoInfo.repo,
+      external_id: "review-bot",
+      conclusion,
+      details_url: this.detailsUrl,
+    });
   }
 }

--- a/src/github/pullRequest.ts
+++ b/src/github/pullRequest.ts
@@ -105,6 +105,13 @@ export class PullRequestApi {
     return this.pr.user.login;
   }
 
+  /**
+   * Generates a Check Run or modifies the existing one.
+   * This way we can aggregate all the results from different causes into a single one
+   * {@link https://docs.github.com/en/rest/checks/runs?apiVersion=2022-11-28}
+   * @param checkResult a CheckData object with the final conclussion of action and the output text
+   * {@link CheckData}
+   */
   async generateCheckRun(checkResult: CheckData): Promise<void> {
     const checkData = {
       ...checkResult,

--- a/src/github/types.ts
+++ b/src/github/types.ts
@@ -8,3 +8,12 @@ export interface ActionLogger {
 }
 
 export type GitHubClient = InstanceType<typeof GitHub>;
+
+export interface CheckData {
+  conclussion: "action_required" | "failure" | "success";
+  output: {
+    title: string;
+    summary: string;
+    text: string;
+  };
+}

--- a/src/github/types.ts
+++ b/src/github/types.ts
@@ -10,7 +10,7 @@ export interface ActionLogger {
 export type GitHubClient = InstanceType<typeof GitHub>;
 
 export interface CheckData {
-  conclussion: "action_required" | "failure" | "success";
+  conclusion: "action_required" | "failure" | "success";
   output: {
     title: string;
     summary: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,7 +72,7 @@ runner
     if (result) {
       info("Action completed succesfully");
     } else {
-      setFailed("Action failed");
+      setFailed("Review requirements failed");
     }
   })
   .catch((error) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,11 +69,7 @@ const runner = new ActionRunner(api, teamApi, logger);
 runner
   .runAction(inputs)
   .then((result) => {
-    if (result) {
-      info("Action completed succesfully");
-    } else {
-      setFailed("Review requirements failed");
-    }
+    info(`Action run without problem. Evaluation result was '${result.conclusion}'`);
   })
   .catch((error) => {
     console.error(error);

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,11 +50,14 @@ debug("Got payload:" + JSON.stringify(context.payload.pull_request));
 
 const inputs = getInputs();
 
+const actionId = `${context.serverUrl}/${repo.owner}/${repo.repo}/actions/runs/${context.runId}`;
+
 const api = new PullRequestApi(
   getOctokit(inputs.repoToken),
   context.payload.pull_request as PullRequest,
   generateCoreLogger(),
   repo,
+  actionId,
 );
 
 const logger = generateCoreLogger();

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,4 +75,7 @@ runner
       setFailed("Action failed");
     }
   })
-  .catch(setFailed);
+  .catch((error) => {
+    console.error(error);
+    setFailed(error as Error | string);
+  });

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -55,7 +55,7 @@ export class ActionRunner {
 
   /**
    * The action evaluates if the rules requirements are meet for a PR
-   * @returns a true/false statement if the rule failed. This WILL BE CHANGED for an object with information (see issue #26)
+   * @returns an array of error reports for each failed rule. An empty array means no errors
    */
   async validatePullRequest({ rules }: ConfigurationFile): Promise<RuleReport[]> {
     const errorReports: RuleReport[] = [];

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -208,7 +208,7 @@ export class ActionRunner {
 
     this.logger.info(success ? "The PR has been successful" : "There was an error with the PR reviews.");
 
-    await this.prApi.generateCheckRun(success ? "success" : "failure");
+    await this.prApi.generateCheckRun(success ? "success" : "failure", 10);
 
     return success;
   }

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -102,9 +102,10 @@ export class ActionRunner {
     }
 
     const { teamsToRequest, usersToRequest } = finalReport;
-    const reviewersLog = teamsToRequest
-      ? `Teams: ${JSON.stringify(teamsToRequest)} - `
-      : "" + (usersToRequest ? `Users: ${JSON.stringify(usersToRequest)}` : "");
+    const reviewersLog = [
+      teamsToRequest ? `Teams: ${JSON.stringify(teamsToRequest)} - ` : "",
+      usersToRequest ? `Users: ${JSON.stringify(usersToRequest)}` : "",
+    ].join(" - ");
 
     this.logger.info(`Need to request reviews from ${reviewersLog}`);
 

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -208,6 +208,8 @@ export class ActionRunner {
 
     this.logger.info(success ? "The PR has been successful" : "There was an error with the PR reviews.");
 
+    await this.prApi.generateCheckRun(success ? "success" : "failure");
+
     return success;
   }
 }

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -116,7 +116,7 @@ export class ActionRunner {
     const missingReviews = reports.reduce((a, b) => a + b.missingReviews, 0);
     const failed = missingReviews > 0;
     const check: CheckData = {
-      conclussion: failed ? "failure" : "success",
+      conclusion: failed ? "failure" : "success",
       output: {
         title: failed ? `Missing ${missingReviews} reviews` : "All required reviews fulfilled",
         summary: failed ? "# The following rules have failed:\n" : "All neccesary users have reviewed the PR",

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -88,7 +88,7 @@ export class ActionRunner {
   }
 
   /** WIP - Class that will assign the requests for review */
-  async requestReviewers(reports: RuleReport[]): Promise<void> {
+  requestReviewers(reports: RuleReport[]): void {
     if (reports.length === 0) {
       return;
     }
@@ -108,8 +108,6 @@ export class ActionRunner {
     ].join(" - ");
 
     this.logger.info(`Need to request reviews from ${reviewersLog}`);
-
-    return await Promise.resolve();
   }
 
   /** Aggregates all the reports and generate a status report */
@@ -259,7 +257,7 @@ export class ActionRunner {
     const checkRunData = this.generateCheckRunData(reports);
     await this.prApi.generateCheckRun(checkRunData);
 
-    await this.requestReviewers(reports);
+    this.requestReviewers(reports);
 
     return checkRunData;
   }


### PR DESCRIPTION
Added ability to generate a status check and the ability to overwrite the latest one.

This resolves #33 and closes #26 as it merged it into one ticket.

There are some limitations as we can not select the check suite that the check will belong (see https://github.com/paritytech/review-bot/issues/33#issuecomment-1662034503), but the name will be constant, making it validable.