### PR TITLE
Created 'OR' rule

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,13 +17,13 @@ jobs:
         run: docker build . --file Dockerfile
   validate-action:
     runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@v3.3.0
       # This checks that .github/workflows/review-bot.yml is pointing towards the main branch
       # as, during development, we change this to use the code from the test branch and
       # we may forget to set it back to main
       - name: Validate that action points to main branch
-        if: github.event_name == 'pull_request'
         run: |
           BRANCH=$(yq '.jobs.review-approvals.steps[1].uses' $FILE_NAME | cut -d "@" -f2)
           # If the branch is not the main branch

--- a/src/rules/types.ts
+++ b/src/rules/types.ts
@@ -2,9 +2,10 @@ export enum RuleTypes {
   Basic = "basic",
   Debug = "debug",
   And = "and",
+  Or = "or",
 }
 
-export type Reviewers = { users?: string[]; teams?: string[] };
+export type Reviewers = { users?: string[]; teams?: string[]; min_approvals: number };
 
 export interface Rule {
   name: string;
@@ -19,21 +20,23 @@ export interface DebugRule extends Rule {
 
 export interface BasicRule extends Rule, Reviewers {
   type: RuleTypes.Basic;
-  min_approvals: number;
 }
 
 export interface AndRule extends Rule {
   type: RuleTypes.And;
-  reviewers: ({
-    min_approvals: number;
-  } & Reviewers)[];
+  reviewers: Reviewers[];
+}
+
+export interface OrRule extends Rule {
+  type: RuleTypes.Or;
+  reviewers: Reviewers[];
 }
 
 export interface ConfigurationFile {
   /** Based on the `type` parameter, Typescript converts the object to the correct type
    * @see {@link Rules}
    */
-  rules: (BasicRule | DebugRule | AndRule)[];
+  rules: (BasicRule | DebugRule | AndRule | OrRule)[];
   preventReviewRequests?: {
     teams?: string[];
     users?: string[];

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -107,10 +107,9 @@ export class ActionRunner {
           // If the loop was not skipped it means that we have errors
           if (reports.length > 0) {
             // We get the lowest amount of reviews needed to fulfill one of the reviews
-            const lowerAmountOfReviewsNeeded = reports.reduce(
-              (a, b) => (a.missingReviews < b.missingReviews ? a : b),
-              10,
-            ).missingReviews;
+            const lowerAmountOfReviewsNeeded = reports
+              .map((r) => r.missingReviews)
+              .reduce((a, b) => (a < b ? a : b), 999);
             // We unify the reports
             const finalReport = unifyReport(reports, rule.name);
             // We set the value to the minimum neccesary

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -106,7 +106,15 @@ export class ActionRunner {
 
           // If the loop was not skipped it means that we have errors
           if (reports.length > 0) {
+            // We get the lowest amount of reviews needed to fulfill one of the reviews
+            const lowerAmountOfReviewsNeeded = reports.reduce(
+              (a, b) => (a.missingReviews < b.missingReviews ? a : b),
+              10,
+            ).missingReviews;
+            // We unify the reports
             const finalReport = unifyReport(reports, rule.name);
+            // We set the value to the minimum neccesary
+            finalReport.missingReviews = lowerAmountOfReviewsNeeded;
             this.logger.error(`Missing the reviews from ${JSON.stringify(finalReport.missingUsers)}`);
             // We unify the reports and push them for handling
             errorReports.push(finalReport);

--- a/src/test/rules/config.test.ts
+++ b/src/test/rules/config.test.ts
@@ -5,6 +5,7 @@ import { mock, MockProxy } from "jest-mock-extended";
 
 import { PullRequestApi } from "../../github/pullRequest";
 import { TeamApi } from "../../github/teams";
+import { RuleTypes } from "../../rules/types";
 import { ActionRunner } from "../../runner";
 import { TestLogger } from "../logger";
 
@@ -71,8 +72,10 @@ describe("Config Parsing", () => {
               teams:
                 - team-example
           `);
+      // prettifies string to [basic, debug, and, or...]
+      const types = JSON.stringify(Object.values(RuleTypes)).replace(/"/g, "").replace(/,/g, ", ");
       await expect(runner.getConfigFile("")).rejects.toThrowError(
-        'Configuration file is invalid: "rules[0].type" must be one of [basic, debug, and]',
+        'Configuration file is invalid: "rules[0].type" must be one of ' + types,
       );
     });
 

--- a/src/test/rules/or.test.ts
+++ b/src/test/rules/or.test.ts
@@ -1,0 +1,200 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+import { mock, MockProxy } from "jest-mock-extended";
+
+import { PullRequestApi } from "../../github/pullRequest";
+import { TeamApi } from "../../github/teams";
+import { OrRule } from "../../rules/types";
+import { ActionRunner } from "../../runner";
+import { TestLogger } from "../logger";
+
+describe("'Or' rule parsing", () => {
+  let api: MockProxy<PullRequestApi>;
+  let runner: ActionRunner;
+  let teamsApi: MockProxy<TeamApi>;
+  let logger: TestLogger;
+  beforeEach(() => {
+    logger = new TestLogger();
+    api = mock<PullRequestApi>();
+    runner = new ActionRunner(api, teamsApi, logger);
+  });
+  test("should get minimal config", async () => {
+    api.getConfigFile.mockResolvedValue(`
+        rules:
+          - name: Test review
+            condition:
+              include: 
+                - '.*'
+              exclude: 
+                - 'example'
+            type: or
+            reviewers:
+              - teams:
+                - team-example
+              - teams:
+                - team-abc
+        `);
+    const config = await runner.getConfigFile("");
+    expect(config.rules[0].name).toEqual("Test review");
+    expect(config.rules[0].type).toEqual("or");
+  });
+
+  describe("reviewers", () => {
+    test("should require teams", async () => {
+      api.getConfigFile.mockResolvedValue(`
+        rules:
+          - name: Test review
+            condition:
+              include: 
+                - '.*'
+              exclude: 
+                - 'example'
+            type: or
+            reviewers:
+              - teams:
+                - team-example
+              - teams:
+                - team-abc
+        `);
+      const config = await runner.getConfigFile("");
+      const rule = config.rules[0] as OrRule;
+      expect(rule.reviewers).toHaveLength(2);
+      expect(rule.reviewers[0].teams).toContainEqual("team-example");
+      expect(rule.reviewers[0].users).toBeUndefined();
+      expect(rule.reviewers[1].teams).toContainEqual("team-abc");
+      expect(rule.reviewers[1].users).toBeUndefined();
+    });
+    test("should require users", async () => {
+      api.getConfigFile.mockResolvedValue(`
+        rules:
+          - name: Test review
+            condition:
+              include: 
+                - '.*'
+              exclude: 
+                - 'example'
+            type: or
+            reviewers:
+              - users:
+                - user-example
+              - users:
+                - user-special
+        `);
+      const config = await runner.getConfigFile("");
+      const rule = config.rules[0] as OrRule;
+      expect(rule.reviewers[0].users).toContainEqual("user-example");
+      expect(rule.reviewers[0].teams).toBeUndefined();
+      expect(rule.reviewers[1].users).toContainEqual("user-special");
+      expect(rule.reviewers[1].teams).toBeUndefined();
+    });
+
+    test("should fail without reviewers", async () => {
+      api.getConfigFile.mockResolvedValue(`
+        rules:
+          - name: Test review
+            condition:
+              include: 
+                - '.*'
+              exclude: 
+                - 'example'
+            type: or
+        `);
+      await expect(runner.getConfigFile("")).rejects.toThrowError('"reviewers" is required');
+    });
+
+    test("should fill the reviewers array", async () => {
+      api.getConfigFile.mockResolvedValue(`
+        rules:
+          - name: Test review
+            condition:
+              include: 
+                - '.*'
+              exclude: 
+                - 'example'
+            type: or
+            reviewers:
+              - teams:
+                - team-example
+              - min_approvals: 2
+                users:
+                  - abc
+                teams:
+                  - xyz
+        `);
+      const config = await runner.getConfigFile("");
+      const rule = config.rules[0] as OrRule;
+      expect(rule.reviewers).toHaveLength(2);
+      expect(rule.reviewers[0].teams).toContainEqual("team-example");
+      expect(rule.reviewers[0].users).toBeUndefined();
+      expect(rule.reviewers[1].min_approvals).toEqual(2);
+      expect(rule.reviewers[1].users).toContainEqual("abc");
+      expect(rule.reviewers[1].teams).toContainEqual("xyz");
+    });
+  });
+
+  test("should default min_approvals to 1", async () => {
+    api.getConfigFile.mockResolvedValue(`
+        rules:
+          - name: Test review
+            condition:
+              include: 
+                - '.*'
+              exclude: 
+                - 'example'
+            type: or
+            reviewers:
+              - users:
+                - user-example
+              - teams:
+                - team-example
+        `);
+    const config = await runner.getConfigFile("");
+    const [rule] = config.rules;
+    if (rule.type === "or") {
+      expect(rule.reviewers[0].min_approvals).toEqual(1);
+    } else {
+      throw new Error(`Rule type ${rule.type} is invalid`);
+    }
+  });
+
+  test("should fail with min_approvals in negative", async () => {
+    api.getConfigFile.mockResolvedValue(`
+        rules:
+          - name: Test review
+            condition:
+              include: 
+                - '.*'
+              exclude: 
+                - 'example'
+            type: or
+            reviewers:
+              - min_approvals: -99
+                users:
+                - user-example
+        `);
+    await expect(runner.getConfigFile("")).rejects.toThrowError(
+      '"reviewers[0].min_approvals" must be greater than or equal to 1',
+    );
+  });
+
+  test("should fail with min_approvals in 0", async () => {
+    api.getConfigFile.mockResolvedValue(`
+        rules:
+          - name: Test review
+            condition:
+              include: 
+                - '.*'
+              exclude: 
+                - 'example'
+            type: or
+            reviewers:
+              - min_approvals: 0
+                users:
+                  - user-example
+        `);
+    await expect(runner.getConfigFile("")).rejects.toThrowError(
+      '"reviewers[0].min_approvals" must be greater than or equal to 1',
+    );
+  });
+});

--- a/src/test/runner/validation/or.test.ts
+++ b/src/test/runner/validation/or.test.ts
@@ -6,7 +6,7 @@ import { ConfigurationFile, RuleTypes } from "../../../rules/types";
 import { ActionRunner } from "../../../runner";
 import { TestLogger } from "../../logger";
 
-describe("'And' rule validation", () => {
+describe("'Or' rule validation", () => {
   let api: MockProxy<PullRequestApi>;
   let teamsApi: MockProxy<TeamApi>;
   let runner: ActionRunner;

--- a/src/test/runner/validation/or.test.ts
+++ b/src/test/runner/validation/or.test.ts
@@ -1,0 +1,127 @@
+import { mock, MockProxy } from "jest-mock-extended";
+
+import { PullRequestApi } from "../../../github/pullRequest";
+import { TeamApi } from "../../../github/teams";
+import { ConfigurationFile, RuleTypes } from "../../../rules/types";
+import { ActionRunner } from "../../../runner";
+import { TestLogger } from "../../logger";
+
+describe("'And' rule validation", () => {
+  let api: MockProxy<PullRequestApi>;
+  let teamsApi: MockProxy<TeamApi>;
+  let runner: ActionRunner;
+  let logger: TestLogger;
+  const users = ["user-1", "user-2", "user-3"];
+  beforeEach(() => {
+    logger = new TestLogger();
+    api = mock<PullRequestApi>();
+    teamsApi = mock<TeamApi>();
+    teamsApi.getTeamMembers.calledWith("abc").mockResolvedValue(users);
+    api.listModifiedFiles.mockResolvedValue([".github/workflows/review-bot.yml"]);
+    api.listApprovedReviewsAuthors.mockResolvedValue([]);
+    runner = new ActionRunner(api, teamsApi, logger);
+  });
+
+  describe("approvals", () => {
+    test("should not report errors if the reviewers reviewed", async () => {
+      const config: ConfigurationFile = {
+        rules: [
+          {
+            name: "Or rule",
+            type: RuleTypes.Or,
+            condition: { include: ["review-bot.yml"] },
+            reviewers: [{ teams: ["abc"], min_approvals: 1 }],
+          },
+        ],
+      };
+      api.listApprovedReviewsAuthors.mockResolvedValue([users[0]]);
+      const evaluation = await runner.validatePullRequest(config);
+      expect(evaluation).toHaveLength(0);
+    });
+
+    test("should not report errors if the reviewer belong to both conditions", async () => {
+      const config: ConfigurationFile = {
+        rules: [
+          {
+            name: "Or rule",
+            type: RuleTypes.Or,
+            condition: { include: ["review-bot.yml"] },
+            reviewers: [
+              { teams: ["abc"], min_approvals: 1 },
+              { users: [users[0]], min_approvals: 1 },
+            ],
+          },
+        ],
+      };
+      api.listApprovedReviewsAuthors.mockResolvedValue([users[0]]);
+      const evaluation = await runner.validatePullRequest(config);
+      expect(evaluation).toHaveLength(0);
+    });
+
+    test("should not report errors if the reviewer belong to one of the conditions", async () => {
+      const config: ConfigurationFile = {
+        rules: [
+          {
+            name: "Or rule",
+            type: RuleTypes.Or,
+            condition: { include: ["review-bot.yml"] },
+            reviewers: [
+              { teams: ["abc"], min_approvals: 1 },
+              { users: [users[0]], min_approvals: 1 },
+              { users: [users[1]], min_approvals: 1 },
+            ],
+          },
+        ],
+      };
+      api.listApprovedReviewsAuthors.mockResolvedValue([users[2]]);
+      const evaluation = await runner.validatePullRequest(config);
+      expect(evaluation).toHaveLength(0);
+    });
+  });
+  describe("errors", () => {
+    test("should report all missing individual users if all of the rules have not been met", async () => {
+      const individualUsers = [users[0], users[1]];
+
+      const config: ConfigurationFile = {
+        rules: [
+          {
+            name: "Or rule",
+            type: RuleTypes.Or,
+            condition: { include: ["review-bot.yml"] },
+            reviewers: [
+              { teams: ["abc"], min_approvals: 1 },
+              { users: individualUsers, min_approvals: 2 },
+            ],
+          },
+        ],
+      };
+      api.listApprovedReviewsAuthors.mockResolvedValue([]);
+      const [result] = await runner.validatePullRequest(config);
+      expect(result.missingReviews).toEqual(1);
+      expect(result.missingUsers).toEqual(users);
+      expect(result.teamsToRequest).toContainEqual("abc");
+      expect(result.usersToRequest).toEqual(individualUsers);
+    });
+
+    test("should show the lowest amount of reviews needed to fulfill the rule", async () => {
+      const config: ConfigurationFile = {
+        rules: [
+          {
+            name: "Or rule",
+            type: RuleTypes.Or,
+            condition: { include: ["review-bot.yml"] },
+            reviewers: [
+              { users: ["abc"], min_approvals: 1 },
+              { users: ["bcd", "cef"], min_approvals: 2 },
+              { users: ["bds", "cj9", "dij", "ehu"], min_approvals: 4 },
+              { users: ["bob", "cat", "dpo", "eio", "fgy"], min_approvals: 5 },
+            ],
+          },
+        ],
+      };
+      api.listApprovedReviewsAuthors.mockResolvedValue([]);
+      const [result] = await runner.validatePullRequest(config);
+      expect(result.missingReviews).toEqual(1);
+    });
+  });
+});


### PR DESCRIPTION
Hello, and welcome to Javier's list of new changes. Today, we have a new feature: **The _OR_ rule**

# List of changes
- Created `OR` rule
  - This resolves #12
  - The OR rule verifies that *one* of the conditions have been fulfilled.
    - When a condition was fulfilled, it continues the loop to the next rule
      - Should this be a "break" instead?
    - When the `OR` rule fails, it shows all the users it needs a review but it only shows the amount of missing reviews using the sub condition with the minimum amount of reviews needed.
    - Created lots of test.
      - This are mainly a copy and modification of `AND` as they share logic and structure.