### PR TITLE
Author as reviewer

### DIFF
--- a/.github/review-bot.yml
+++ b/.github/review-bot.yml
@@ -12,10 +12,11 @@ rules:
     condition:
       include:
         - 'review-bot.yml'
-    type: and
+    type: and-distinct
     reviewers:
       - teams:
         - opstooling
+        countAuthor: true
       - users:
         - mordamax
         - mutantcornholio

--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ rules:
         - '.*'
       exclude: 
         - 'example'
+    countAuthor: true
     type: or | and | and-distinct
     reviewers:
       - teams:
@@ -247,10 +248,12 @@ rules:
       - teams:
         - team-abc
         min_approvals: 2
-        countAuthor: true
 ```
 - The **name** and **conditions** fields have the same requirements that the `basic` rule has.
 - **type**: Must be `or`, `and` or `and-distinct`.
+- **countAuthor**: If the pull request author should be considered as an approval.
+	- If the author belongs to the list of approved users (either by team or by users) his approval will be counted (requiring one less approvals in total).
+	- ** Optional**: Defaults to `false`
 - **reviewers**: This is an array that contains all the available options for review.
 	- Each of these options works independently.
 	- Must have at least two options.
@@ -264,10 +267,6 @@ rules:
 			- *Optional if **users** is defined*.
 		- **users**: An array of the GitHub usernames of the users who need to review this file. 
 			- *Optional if **teams** is defined*.
-		-  **countAuthor**: If the pull request author should be considered as an approval.
-			- If the author belongs to the list of approved users (either by team or by users) his approval will be counted (requiring one less approvals in total).
-			- ** Optional**: Defaults to `false`
-
 ##### Or rule logic
 This is a rule that has at least two available options of reviewers and needs **at least one group to approve**.
 

--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ rules:
     users:
       - user-1
       - user-2
+    countAuthor: true
 ```
 It has the same parameters as a normal rule:
 -  **name**: Name of the rule. This value must be unique per rule.
@@ -223,6 +224,9 @@ It has the same parameters as a normal rule:
 	- *Optional if **users** is defined*.
 - **users**: An array of the GitHub usernames of the users who need to review this file. 
 	- *Optional if **teams** is defined*.
+- **countAuthor**: If the pull request author should be considered as an approval.
+	- If the author belongs to the list of approved users (either by team or by users) his approval will be counted (requiring one less approvals in total).
+	- ** Optional**: Defaults to `false`
 #### Other rules
 The other three rules (**or**, **and** and **and-distinct**) have the same configuration, so let’s summarize that here and then move into how they work.
 ```yaml
@@ -243,6 +247,7 @@ rules:
       - teams:
         - team-abc
         min_approvals: 2
+        countAuthor: true
 ```
 - The **name** and **conditions** fields have the same requirements that the `basic` rule has.
 - **type**: Must be `or`, `and` or `and-distinct`.
@@ -259,6 +264,9 @@ rules:
 			- *Optional if **users** is defined*.
 		- **users**: An array of the GitHub usernames of the users who need to review this file. 
 			- *Optional if **teams** is defined*.
+		-  **countAuthor**: If the pull request author should be considered as an approval.
+			- If the author belongs to the list of approved users (either by team or by users) his approval will be counted (requiring one less approvals in total).
+			- ** Optional**: Defaults to `false`
 
 ##### Or rule logic
 This is a rule that has at least two available options of reviewers and needs **at least one group to approve**.

--- a/src/github/pullRequest.ts
+++ b/src/github/pullRequest.ts
@@ -53,7 +53,7 @@ export class PullRequestApi {
   }
 
   /** List all the approved reviews in a PR */
-  async listApprovedReviewsAuthors(): Promise<string[]> {
+  async listApprovedReviewsAuthors(countAuthor: boolean): Promise<string[]> {
     if (!this.usersThatApprovedThePr) {
       const request = await this.api.rest.pulls.listReviews({ ...this.repoInfo, pull_number: this.number });
       const reviews = request.data as PullRequestReview[];
@@ -97,6 +97,12 @@ export class PullRequestApi {
       this.usersThatApprovedThePr = approvals.map((approval) => approval.user.login);
     }
     this.logger.debug(`PR approvals are ${JSON.stringify(this.usersThatApprovedThePr)}`);
+
+    if (countAuthor) {
+      // If this value is true, we add the author to the list of approvals
+      return [...this.usersThatApprovedThePr, this.pr.user.login];
+    }
+
     return this.usersThatApprovedThePr;
   }
 

--- a/src/rules/types.ts
+++ b/src/rules/types.ts
@@ -6,7 +6,7 @@ export enum RuleTypes {
   AndDistinct = "and-distinct",
 }
 
-export type Reviewers = { users?: string[]; teams?: string[]; min_approvals: number };
+export type Reviewers = { users?: string[]; teams?: string[]; min_approvals: number; countAuthor?: boolean };
 
 export interface Rule {
   name: string;

--- a/src/rules/types.ts
+++ b/src/rules/types.ts
@@ -6,11 +6,12 @@ export enum RuleTypes {
   AndDistinct = "and-distinct",
 }
 
-export type Reviewers = { users?: string[]; teams?: string[]; min_approvals: number; countAuthor?: boolean };
+export type Reviewers = { users?: string[]; teams?: string[]; min_approvals: number };
 
 export interface Rule {
   name: string;
   condition: { include: string[]; exclude?: string[] };
+  countAuthor?: boolean;
 }
 
 // TODO: Delete this once we add a second type of rule

--- a/src/rules/validator.ts
+++ b/src/rules/validator.ts
@@ -46,6 +46,7 @@ export const basicRuleSchema = Joi.object<BasicRule>()
 /** As, with the exception of basic, every other schema has the same structure, we can recycle this */
 export const otherRulesSchema = Joi.object<AndRule>().keys({
   reviewers: Joi.array<AndRule["reviewers"]>().items(basicRuleSchema).min(2).required(),
+  countAuthor: Joi.boolean().default(false),
 });
 
 /**

--- a/src/rules/validator.ts
+++ b/src/rules/validator.ts
@@ -40,7 +40,7 @@ export const generalSchema = Joi.object<ConfigurationFile>().keys({
  * This rule is quite simple as it only has the min_approvals field and the required reviewers
  */
 export const basicRuleSchema = Joi.object<BasicRule>()
-  .keys({ min_approvals: Joi.number().min(1).default(1), ...reviewersObj })
+  .keys({ min_approvals: Joi.number().min(1).default(1), ...reviewersObj, countAuthor: Joi.boolean().default(false) })
   .or("users", "teams");
 
 /** As, with the exception of basic, every other schema has the same structure, we can recycle this */
@@ -70,6 +70,8 @@ export const validateConfig = (config: ConfigurationFile): ConfigurationFile | n
     } else if (type === "debug") {
       validatedConfig.rules[i] = validate<DebugRule>(rule, ruleSchema, { message });
     } else if (type === "and" || type === "or" || type === "and-distinct") {
+      // Aside from the type, every other field in this rules is identical so we can
+      // use any of these rules to validate the other fields.
       validatedConfig.rules[i] = validate<AndRule>(rule, otherRulesSchema, { message });
     } else {
       // eslint-disable-next-line @typescript-eslint/restrict-template-expressions

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -234,7 +234,8 @@ export class ActionRunner {
 
     // We count how many reviews are needed in total
     const requiredAmountOfReviews = rule.reviewers.map((r) => r.min_approvals).reduce((a, b) => a + b, 0);
-    // We get the list of users that approved the PR
+    // We get the list of users that approved the PR and the author
+    // we filter the author later
     const approvals = await this.prApi.listApprovedReviewsAuthors(true);
 
     // Utility method used to generate error
@@ -270,7 +271,10 @@ export class ActionRunner {
     // Now we see, from all the approvals, which approvals could match each rule
     for (const { users, requiredApprovals, countAuthor } of requirements) {
       const ruleApprovals = approvals.filter(
-        (ap) => users.indexOf(ap) !== -1 && (countAuthor ? true : ap !== this.prApi.getAuthor()),
+        (ap) =>
+          users.indexOf(ap) !== -1 &&
+          // If we are not counting the author we remove them from the equation
+          (countAuthor ? true : ap !== this.prApi.getAuthor()),
       );
       conditionApprovals.push({ matchingUsers: ruleApprovals, requiredUsers: users, requiredApprovals });
     }

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -267,10 +267,12 @@ export class ActionRunner {
       requiredApprovals: number;
     }[] = [];
 
+    const author = this.prApi.getAuthor();
+
     // Now we see, from all the approvals, which approvals could match each rule
     for (const { users, requiredApprovals, countAuthor } of requirements) {
       const ruleApprovals = approvals.filter((ap) => users.indexOf(ap) !== -1);
-      const author = this.prApi.getAuthor();
+
       if (countAuthor && users.indexOf(author) > -1) {
         ruleApprovals.push(this.prApi.getAuthor());
       }

--- a/src/test/github.test.ts
+++ b/src/test/github.test.ts
@@ -1,0 +1,79 @@
+import { PullRequest, PullRequestReview } from "@octokit/webhooks-types";
+import { DeepMockProxy, mock, mockDeep, MockProxy } from "jest-mock-extended";
+
+import { PullRequestApi } from "../github/pullRequest";
+import { ActionLogger, GitHubClient } from "../github/types";
+
+describe("Pull Request API Tests", () => {
+  let api: PullRequestApi;
+  let logger: MockProxy<ActionLogger>;
+  let client: DeepMockProxy<GitHubClient>;
+  let pr: DeepMockProxy<PullRequest>;
+  beforeEach(() => {
+    logger = mock<ActionLogger>();
+    client = mockDeep<GitHubClient>();
+    pr = mockDeep<PullRequest>();
+    pr.number = 99;
+    api = new PullRequestApi(client, pr, logger, { owner: "org", repo: "repo" }, "");
+  });
+
+  describe("Approvals", () => {
+    const random = () => Math.floor(Math.random() * 1000);
+
+    let reviews: PullRequestReview[];
+    beforeEach(() => {
+      reviews = [];
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore because the official type and the library type do not match
+      client.rest.pulls.listReviews.mockResolvedValue({ data: reviews as unknown });
+    });
+
+    test("Should return approval", async () => {
+      const mockReviews: PullRequestReview[] = [
+        { state: "approved", user: { login: "yes-user", id: random() }, id: random() },
+      ] as PullRequestReview[];
+      reviews.push(...mockReviews);
+
+      const approvals = await api.listApprovedReviewsAuthors(false);
+      expect(approvals).toEqual(["yes-user"]);
+    });
+
+    test("Should return approvals and ignore other reviews", async () => {
+      const mockReviews: PullRequestReview[] = [
+        { state: "changes_requested", user: { login: "no-user", id: random() }, id: random() },
+        { state: "approved", user: { login: "yes-user", id: random() }, id: random() },
+        { state: "commented", user: { login: "other-user", id: random() }, id: random() },
+      ] as PullRequestReview[];
+      reviews.push(...mockReviews);
+
+      const approvals = await api.listApprovedReviewsAuthors(false);
+      expect(approvals).toEqual(["yes-user"]);
+    });
+
+    test("Should consider only oldest reviews per user", async () => {
+      const mockReviews: PullRequestReview[] = [
+        { state: "changes_requested", user: { login: "user-1", id: 1 }, id: 1000 },
+        { state: "approved", user: { login: "user-2", id: 2 }, id: 1200 },
+        { state: "approved", user: { login: "user-1", id: 1 }, id: 1500 },
+        { state: "changes_requested", user: { login: "user-2", id: 2 }, id: 1600 },
+      ] as PullRequestReview[];
+      reviews.push(...mockReviews);
+
+      const approvals = await api.listApprovedReviewsAuthors(false);
+      expect(approvals).toEqual(["user-1"]);
+    });
+
+    test("Should return approvals and the author", async () => {
+      pr.user.login = "abc";
+      const mockReviews: PullRequestReview[] = [
+        { state: "changes_requested", user: { login: "no-user", id: random() }, id: random() },
+        { state: "approved", user: { login: "yes-user", id: random() }, id: random() },
+        { state: "commented", user: { login: "other-user", id: random() }, id: random() },
+      ] as PullRequestReview[];
+      reviews.push(...mockReviews);
+
+      const approvals = await api.listApprovedReviewsAuthors(true);
+      expect(approvals).toEqual(["yes-user", "abc"]);
+    });
+  });
+});

--- a/src/test/rules/basicRule.test.ts
+++ b/src/test/rules/basicRule.test.ts
@@ -143,4 +143,66 @@ describe("Basic rule parsing", () => {
         `);
     await expect(runner.getConfigFile("")).rejects.toThrowError('"min_approvals" must be greater than or equal to 1');
   });
+
+  test("should default countAuthor to false", async () => {
+    api.getConfigFile.mockResolvedValue(`
+        rules:
+          - name: Test review
+            condition:
+              include: 
+                - '.*'
+              exclude: 
+                - 'example'
+            type: basic
+            users:
+              - user-example
+        `);
+    const config = await runner.getConfigFile("");
+    const [rule] = config.rules;
+    if (rule.type === "basic") {
+      expect(rule.countAuthor).toBeFalsy();
+    } else {
+      throw new Error(`Rule type ${rule.type} is invalid`);
+    }
+  });
+
+  test("should fail if countAuthor is not a boolean", async () => {
+    api.getConfigFile.mockResolvedValue(`
+        rules:
+          - name: Test review
+            condition:
+              include: 
+                - '.*'
+              exclude: 
+                - 'example'
+            type: basic
+            users:
+              - user-example
+            countAuthor: bla
+        `);
+    await expect(runner.getConfigFile("")).rejects.toThrowError('"countAuthor" must be a boolean');
+  });
+
+  test("should set countAuthor to true", async () => {
+    api.getConfigFile.mockResolvedValue(`
+        rules:
+          - name: Test review
+            condition:
+              include: 
+                - '.*'
+              exclude: 
+                - 'example'
+            type: basic
+            users:
+              - user-example
+            countAuthor: true
+        `);
+    const config = await runner.getConfigFile("");
+    const [rule] = config.rules;
+    if (rule.type === "basic") {
+      expect(rule.countAuthor).toBeTruthy();
+    } else {
+      throw new Error(`Rule type ${rule.type} is invalid`);
+    }
+  });
 });

--- a/src/test/rules/or.test.ts
+++ b/src/test/rules/or.test.ts
@@ -197,4 +197,75 @@ describe("'Or' rule parsing", () => {
       '"reviewers[0].min_approvals" must be greater than or equal to 1',
     );
   });
+
+  test("should default countAuthor to false", async () => {
+    api.getConfigFile.mockResolvedValue(`
+    rules:
+    - name: Test review
+      condition:
+        include: 
+          - '.*'
+        exclude: 
+          - 'example'
+      type: or
+      reviewers:
+        - teams:
+          - team-example
+        - users:
+            - user-example
+        `);
+    const config = await runner.getConfigFile("");
+    const [rule] = config.rules;
+    if (rule.type === "or") {
+      expect(rule.reviewers[1].countAuthor).toBeFalsy();
+    } else {
+      throw new Error(`Rule type ${rule.type} is invalid`);
+    }
+  });
+
+  test("should fail if countAuthor is not a boolean", async () => {
+    api.getConfigFile.mockResolvedValue(`
+        rules:
+        - name: Test review
+          condition:
+            include: 
+              - '.*'
+            exclude: 
+              - 'example'
+          type: or
+          reviewers:
+            - teams:
+              - team-example
+            - users:
+                - user-example
+              countAuthor: bla
+        `);
+    await expect(runner.getConfigFile("")).rejects.toThrowError('"reviewers[1].countAuthor" must be a boolean');
+  });
+
+  test("should set countAuthor to true", async () => {
+    api.getConfigFile.mockResolvedValue(`
+        rules:
+        - name: Test review
+          condition:
+            include: 
+              - '.*'
+            exclude: 
+              - 'example'
+          type: or
+          reviewers:
+            - teams:
+              - team-example
+            - users:
+                - user-example
+              countAuthor: true
+        `);
+    const config = await runner.getConfigFile("");
+    const [rule] = config.rules;
+    if (rule.type === "or") {
+      expect(rule.reviewers[1].countAuthor).toBeTruthy();
+    } else {
+      throw new Error(`Rule type ${rule.type} is invalid`);
+    }
+  });
 });

--- a/src/test/rules/or.test.ts
+++ b/src/test/rules/or.test.ts
@@ -217,7 +217,7 @@ describe("'Or' rule parsing", () => {
     const config = await runner.getConfigFile("");
     const [rule] = config.rules;
     if (rule.type === "or") {
-      expect(rule.reviewers[1].countAuthor).toBeFalsy();
+      expect(rule.countAuthor).toBeFalsy();
     } else {
       throw new Error(`Rule type ${rule.type} is invalid`);
     }
@@ -227,6 +227,7 @@ describe("'Or' rule parsing", () => {
     api.getConfigFile.mockResolvedValue(`
         rules:
         - name: Test review
+          countAuthor: bla
           condition:
             include: 
               - '.*'
@@ -238,9 +239,8 @@ describe("'Or' rule parsing", () => {
               - team-example
             - users:
                 - user-example
-              countAuthor: bla
         `);
-    await expect(runner.getConfigFile("")).rejects.toThrowError('"reviewers[1].countAuthor" must be a boolean');
+    await expect(runner.getConfigFile("")).rejects.toThrowError('"countAuthor" must be a boolean');
   });
 
   test("should set countAuthor to true", async () => {
@@ -252,18 +252,18 @@ describe("'Or' rule parsing", () => {
               - '.*'
             exclude: 
               - 'example'
+          countAuthor: true
           type: or
           reviewers:
             - teams:
               - team-example
             - users:
                 - user-example
-              countAuthor: true
         `);
     const config = await runner.getConfigFile("");
     const [rule] = config.rules;
     if (rule.type === "or") {
-      expect(rule.reviewers[1].countAuthor).toBeTruthy();
+      expect(rule.countAuthor).toBeTruthy();
     } else {
       throw new Error(`Rule type ${rule.type} is invalid`);
     }

--- a/src/test/runner/validation/andDistinct.test.ts
+++ b/src/test/runner/validation/andDistinct.test.ts
@@ -141,7 +141,7 @@ describe("'And' rule validation", () => {
         name: "test",
         condition: { include: [] },
       };
-      api.listApprovedReviewsAuthors.mockResolvedValue([...users, "random"]);
+      api.listApprovedReviewsAuthors.mockResolvedValue([...users]);
       api.getAuthor.mockReturnValue("random");
       const [result] = await runner.andDistinctEvaluation(rule);
       expect(result).toBe(false);
@@ -227,18 +227,18 @@ describe("'And' rule validation", () => {
       expect(result).toBe(true);
     });
 
-    test("should consider author in evaluation", async () => {
+    test.only("should consider author in evaluation", async () => {
       const rule: AndDistinctRule = {
         type: RuleTypes.AndDistinct,
         reviewers: [
-          { users: [users[0], "example", "random"], countAuthor: true, min_approvals: 2 },
+          { users: [users[0], "example", "author"], countAuthor: true, min_approvals: 2 },
           { teams: ["team-abc"], min_approvals: 1 },
         ],
         name: "test",
         condition: { include: [] },
       };
-      api.listApprovedReviewsAuthors.mockResolvedValue([...users, "random"]);
-      api.getAuthor.mockReturnValue("random");
+      api.listApprovedReviewsAuthors.mockResolvedValue(users);
+      api.getAuthor.mockReturnValue("author");
       const [result] = await runner.andDistinctEvaluation(rule);
       expect(result).toBe(true);
     });

--- a/src/test/runner/validation/andDistinct.test.ts
+++ b/src/test/runner/validation/andDistinct.test.ts
@@ -7,7 +7,7 @@ import { ActionLogger } from "../../../github/types";
 import { AndDistinctRule, RuleTypes } from "../../../rules/types";
 import { ActionRunner } from "../../../runner";
 
-describe("'And' rule validation", () => {
+describe("'And distinct' rule validation", () => {
   let api: MockProxy<PullRequestApi>;
   let teamsApi: MockProxy<TeamApi>;
   let runner: ActionRunner;
@@ -134,8 +134,9 @@ describe("'And' rule validation", () => {
     test("should not consider author in evaluation", async () => {
       const rule: AndDistinctRule = {
         type: RuleTypes.AndDistinct,
+        countAuthor: false,
         reviewers: [
-          { users: [users[0], "example", "random"], countAuthor: false, min_approvals: 2 },
+          { users: [users[0], "example", "random"], min_approvals: 2 },
           { teams: ["team-abc"], min_approvals: 1 },
         ],
         name: "test",
@@ -227,11 +228,12 @@ describe("'And' rule validation", () => {
       expect(result).toBe(true);
     });
 
-    test.only("should consider author in evaluation", async () => {
+    test("should consider author in evaluation", async () => {
       const rule: AndDistinctRule = {
         type: RuleTypes.AndDistinct,
+        countAuthor: true,
         reviewers: [
-          { users: [users[0], "example", "author"], countAuthor: true, min_approvals: 2 },
+          { users: [users[0], "example", "author"], min_approvals: 2 },
           { teams: ["team-abc"], min_approvals: 1 },
         ],
         name: "test",

--- a/src/test/runner/validation/andDistinct.test.ts
+++ b/src/test/runner/validation/andDistinct.test.ts
@@ -116,21 +116,6 @@ describe("'And distinct' rule validation", () => {
       expect(logger.warn).toHaveBeenCalledWith("Not enough positive reviews to match a subcondition");
     });
 
-    test("should evaluate splitting requirements with this setup", async () => {
-      const rule: AndDistinctRule = {
-        type: RuleTypes.AndDistinct,
-        reviewers: [
-          { users: ["user-1", "user-2"], min_approvals: 2 },
-          { users: ["user-1"], min_approvals: 1 },
-        ],
-        name: "test",
-        condition: { include: [] },
-      };
-      api.listApprovedReviewsAuthors.mockResolvedValue(users);
-      const [result] = await runner.andDistinctEvaluation(rule);
-      expect(result).toBe(false);
-    });
-
     test("should not consider author in evaluation", async () => {
       const rule: AndDistinctRule = {
         type: RuleTypes.AndDistinct,
@@ -228,7 +213,7 @@ describe("'And distinct' rule validation", () => {
       expect(result).toBe(true);
     });
 
-    test("should consider author in evaluation", async () => {
+    test("should call listApprovedReviewsAuthors with true", async () => {
       const rule: AndDistinctRule = {
         type: RuleTypes.AndDistinct,
         countAuthor: true,
@@ -239,7 +224,7 @@ describe("'And distinct' rule validation", () => {
         name: "test",
         condition: { include: [] },
       };
-      api.listApprovedReviewsAuthors.mockResolvedValue([users[0], users[1], users[2]]);
+      api.listApprovedReviewsAuthors.mockResolvedValue(users);
       const [result] = await runner.andDistinctEvaluation(rule);
       expect(result).toBe(true);
       expect(api.listApprovedReviewsAuthors).lastCalledWith(true);

--- a/src/test/runner/validation/andDistinct.test.ts
+++ b/src/test/runner/validation/andDistinct.test.ts
@@ -233,16 +233,16 @@ describe("'And distinct' rule validation", () => {
         type: RuleTypes.AndDistinct,
         countAuthor: true,
         reviewers: [
-          { users: [users[0], "example", "author"], min_approvals: 2 },
-          { teams: ["team-abc"], min_approvals: 1 },
+          { users: [users[0], "example"], min_approvals: 1 },
+          { teams: ["team-abc"], min_approvals: 2 },
         ],
         name: "test",
         condition: { include: [] },
       };
-      api.listApprovedReviewsAuthors.mockResolvedValue(users);
-      api.getAuthor.mockReturnValue("author");
+      api.listApprovedReviewsAuthors.mockResolvedValue([users[0], users[1], users[2]]);
       const [result] = await runner.andDistinctEvaluation(rule);
       expect(result).toBe(true);
+      expect(api.listApprovedReviewsAuthors).lastCalledWith(true);
     });
   });
 });


### PR DESCRIPTION
Resolves #34

Created the option to count the author of a PR as an approval.
This has to be set per review option.

In the case of the "normal" rules it doesn't change the logic.

In the case of the "and-distinct" rule we have to decide if we filter the author from the PR on evaluation time.