### PR TITLE
Prevent review request

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,11 +169,12 @@ interface Report {
 ## Rule configuration file
 This is the file where all the available rules are written. 
 
-**This file is only read from the main branch.** So if you modify the file the changes won’t happen until it is merged into the main branch. 
-This is done to stop users from modifying the rules in their own PRs.
+**This file is only read from the main branch.** So if you modify the file, the changes won’t happen until it is merged into the main branch. 
+This is done to stop users from modifying the rules in their PRs.
 
-It contains an object called `rules` which has an array of rules. Every rule has a same base structure:
+It contains an object called `rules` which has an array of rules. Every rule has a same base structure. There is also a second optional field called `preventReviewRequests`.
 ```yaml
+rules:
   - name: Rule name
     condition:
       include:
@@ -181,8 +182,17 @@ It contains an object called `rules` which has an array of rules. Every rule has
       exclude:
         - 'README.md'
     type: the type of the rule
+
+preventReviewRequests:
+  users:
+    - user-a
+    - user-b
+  teams:
+    - team-a
+    - team-b
 ```
 
+#### Rules fields
 - **name**: Name of the rule. This value must be unique per rule.
 - **condition**: This is an object that contains two values:
 	- **include**: An array of regex expressions of the files that match this rule.
@@ -197,8 +207,19 @@ It contains an object called `rules` which has an array of rules. Every rule has
 			- **or**: Has many review options, requires at least *one option* to be fulfilled.
 			- **and**: Has many review options, requires *all the options* to be fulfilled.
 			-  **and-distinct**: Has many review options, requires *all the options* to be fulfilled *by different people*.
+
+#### preventReviewRequests
+This is a special field that applies to all the rules.
+
+This field is **optional**.
+
+It supports two fields: `users` and `teams`. If *the user is inside the users array, or they belong to one of the teams listed there, the validation will automatically be skipped, and a success status check will be reported*.
+
+It is intended to stop the custom rules being required when a user is already trusted and doesn’t need such a thorough review process.
+
 ### Types
 Every type has a *slightly* different configuration and works for different scenarios, so let’s analyze all of them.
+
 #### Basic rule
 As the name implies, this type is elementary. All the files that fall under the rule evaluation must receive a given number of approvals by the listed users and/or team members.
 

--- a/README.md
+++ b/README.md
@@ -211,11 +211,8 @@ preventReviewRequests:
 #### preventReviewRequests
 This is a special field that applies to all the rules.
 
-This field is **optional**.
+This field is **optional** and currently not used. Pending on https://github.com/paritytech/review-bot/issues/53
 
-It supports two fields: `users` and `teams`. If *the author of the Pull Request is inside the users array, or they belong to one of the teams listed there, the validation will automatically be skipped, and a success status check will be reported*.
-
-It is intended to stop the custom rules being required when a user is already trusted and doesn’t need such a thorough review process.
 
 ### Types
 Every type has a *slightly* different configuration and works for different scenarios, so let’s analyze all of them.

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ This is a special field that applies to all the rules.
 
 This field is **optional**.
 
-It supports two fields: `users` and `teams`. If *the user is inside the users array, or they belong to one of the teams listed there, the validation will automatically be skipped, and a success status check will be reported*.
+It supports two fields: `users` and `teams`. If *the author of the Pull Request is inside the users array, or they belong to one of the teams listed there, the validation will automatically be skipped, and a success status check will be reported*.
 
 It is intended to stop the custom rules being required when a user is already trusted and doesn’t need such a thorough review process.
 

--- a/src/rules/validator.ts
+++ b/src/rules/validator.ts
@@ -34,7 +34,7 @@ const ruleSchema = Joi.object<Rule & { type: string }>().keys({
  */
 export const generalSchema = Joi.object<ConfigurationFile>().keys({
   rules: Joi.array<ConfigurationFile["rules"]>().items(ruleSchema).unique("name").required(),
-  preventReviewRequests: Joi.object().keys(reviewersObj).optional().xor("users", "teams"),
+  preventReviewRequests: Joi.object().keys(reviewersObj).optional().or("users", "teams"),
 });
 
 /** Basic rule schema

--- a/src/rules/validator.ts
+++ b/src/rules/validator.ts
@@ -10,8 +10,9 @@ import { AndRule, BasicRule, ConfigurationFile, DebugRule, Reviewers, Rule, Rule
 const reviewersObj = {
   users: Joi.array().items(Joi.string()).optional().empty(null),
   teams: Joi.array().items(Joi.string()).optional().empty(null),
-  min_approvals: Joi.number().min(1).default(1),
 };
+
+const reviewerConditionObj = { ...reviewersObj, min_approvals: Joi.number().min(1).default(1) };
 
 /** Base rule condition.
  * This are the minimum requirements that all the rules must have.
@@ -41,13 +42,13 @@ export const generalSchema = Joi.object<ConfigurationFile>().keys({
  * This rule is quite simple as it only has the min_approvals field and the required reviewers
  */
 export const basicRuleSchema = Joi.object<BasicRule>()
-  .keys({ ...reviewersObj, countAuthor: Joi.boolean().default(false) })
+  .keys({ ...reviewerConditionObj, countAuthor: Joi.boolean().default(false) })
   .or("users", "teams");
 
 /** As, with the exception of basic, every other schema has the same structure, we can recycle this */
 export const otherRulesSchema = Joi.object<AndRule>().keys({
   reviewers: Joi.array<AndRule["reviewers"]>()
-    .items(Joi.object<Reviewers>().keys(reviewersObj).or("users", "teams"))
+    .items(Joi.object<Reviewers>().keys(reviewerConditionObj).or("users", "teams"))
     .min(2)
     .required(),
   countAuthor: Joi.boolean().default(false),

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -355,7 +355,7 @@ export class ActionRunner {
 
     const author = this.prApi.getAuthor();
 
-    if (preventReviewRequests.users && preventReviewRequests.users.indexOf(author)) {
+    if (preventReviewRequests.users && preventReviewRequests.users.indexOf(author) > -1) {
       this.logger.info("User does belongs to list of users to prevent the review request.");
       return true;
     }
@@ -364,7 +364,7 @@ export class ActionRunner {
       for (const team of preventReviewRequests.teams) {
         const members = await this.teamApi.getTeamMembers(team);
         if (members.indexOf(author) > -1) {
-          this.logger.info(`User belong to the team ${team} which is part of the preventReviewRequests.`);
+          this.logger.info(`User belong to the team '${team}' which is part of the preventReviewRequests.`);
           return true;
         }
       }

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -66,14 +66,8 @@ export class ActionRunner {
    * The action evaluates if the rules requirements are meet for a PR
    * @returns an array of error reports for each failed rule. An empty array means no errors
    */
-  async validatePullRequest({ rules, preventReviewRequests }: ConfigurationFile): Promise<PullRequestReport> {
+  async validatePullRequest({ rules }: ConfigurationFile): Promise<PullRequestReport> {
     const modifiedFiles = await this.prApi.listModifiedFiles();
-
-    // verify if we should skip the validation
-    if (await this.preventReviewEvaluation({ preventReviewRequests })) {
-      this.logger.info("Skipping validation. User belongs to 'preventReviewRequests'");
-      return { files: modifiedFiles, reports: [] };
-    }
 
     const errorReports: RuleReport[] = [];
 
@@ -176,14 +170,14 @@ export class ActionRunner {
     if (preventReviewRequests) {
       if (
         preventReviewRequests.teams &&
-        teamsToRequest?.some((team) => preventReviewRequests.teams?.indexOf(team) === -1)
+        teamsToRequest?.some((team) => preventReviewRequests.teams?.indexOf(team) !== -1)
       ) {
         this.logger.info("Filtering teams to request a review from.");
         teamsToRequest = teamsToRequest?.filter((team) => preventReviewRequests.teams?.indexOf(team) === -1);
       }
       if (
         preventReviewRequests.users &&
-        usersToRequest?.some((user) => preventReviewRequests.users?.indexOf(user) === -1)
+        usersToRequest?.some((user) => preventReviewRequests.users?.indexOf(user) !== -1)
       ) {
         this.logger.info("Filtering users to request a review from.");
         usersToRequest = usersToRequest?.filter((user) => preventReviewRequests.users?.indexOf(user) === -1);

--- a/src/test/rules/config.test.ts
+++ b/src/test/rules/config.test.ts
@@ -169,32 +169,6 @@ describe("Config Parsing", () => {
       expect(config.preventReviewRequests?.users).toEqual(["user-a", "user-b"]);
     });
 
-    test("should fail with both users and teams", async () => {
-      api.getConfigFile.mockResolvedValue(`
-      rules:
-        - name: Default review
-          condition:
-            include: 
-                - '.*'
-            exclude: 
-                - 'example'
-          type: basic
-          teams:
-            - team-example
-
-      preventReviewRequests:
-        users:
-          - user-a
-          - user-b
-        teams:
-              - team-a
-              - team-b
-        `);
-      await expect(runner.getConfigFile("")).rejects.toThrowError(
-        '"preventReviewRequests" contains a conflict between exclusive peers [users, teams]',
-      );
-    });
-
     test("should pass if preventReviewRequests is not assigned", async () => {
       api.getConfigFile.mockResolvedValue(`
       rules:

--- a/src/test/rules/config.test.ts
+++ b/src/test/rules/config.test.ts
@@ -169,6 +169,32 @@ describe("Config Parsing", () => {
       expect(config.preventReviewRequests?.users).toEqual(["user-a", "user-b"]);
     });
 
+    test("should get both users and teams", async () => {
+      api.getConfigFile.mockResolvedValue(`
+      rules:
+        - name: Default review
+          condition:
+            include: 
+                - '.*'
+            exclude: 
+                - 'example'
+          type: basic
+          teams:
+            - team-example
+
+      preventReviewRequests:
+        users:
+          - user-a
+          - user-b
+        teams:
+          - team-a
+          - team-b
+        `);
+      const config = await runner.getConfigFile("");
+      expect(config.preventReviewRequests?.users).toEqual(["user-a", "user-b"]);
+      expect(config.preventReviewRequests?.teams).toEqual(["team-a", "team-b"]);
+    });
+
     test("should pass if preventReviewRequests is not assigned", async () => {
       api.getConfigFile.mockResolvedValue(`
       rules:

--- a/src/test/runner/runner.test.ts
+++ b/src/test/runner/runner.test.ts
@@ -15,7 +15,9 @@ describe("Shared validations", () => {
   let runner: ActionRunner;
   beforeEach(() => {
     api = mock<PullRequestApi>();
-    runner = new ActionRunner(api, teamsApi, logger);
+    logger = mock<ActionLogger>();
+    teamsApi = mock<TeamApi>();
+    runner = new ActionRunner(api, teamsApi, mock<GitHubChecksApi>(), logger);
   });
 
   test("validatePullRequest should return true if no rule matches any files", async () => {


### PR DESCRIPTION
Added the feature `Prevent review request`

Thie resolves #59.

It allows us to not request the review of some teams or users.

As we don't have the request review implementation yet (see #53), I didn't add any explanation in the README.