### PR TITLE
Added excludeAuthors feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ It has the same parameters as a normal rule:
 - **countAuthor**: If the pull request author should be considered as an approval.
 	- If the author belongs to the list of approved users (either by team or by users) his approval will be counted (requiring one less approvals in total).
 	- ** Optional**: Defaults to `false`
-- **excludeAuthor**: If the author belong to one of the teams and/or users in the list, the rule should be skipped.
+- **allowedToSkipRule**: If the author belong to one of the teams and/or users in the list, the rule should be skipped.
 	- **Optional**.
 	- This is useful for cases where we want to make sure that some eyes look into a PR, but for we don’t need to ensure that much security on internal teams.
 		- For example, if someone modifies a CI file, we want to make sure they didn’t break anything. Unless it’s someone from the CI team. They *should know* what they are doing.

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ rules:
       - user-1
       - user-2
     countAuthor: true
-    excludeAuthors:
+    allowedToSkipRule:
       teams:
         - team-1
       users:

--- a/README.md
+++ b/README.md
@@ -238,6 +238,11 @@ rules:
       - user-1
       - user-2
     countAuthor: true
+    excludeAuthors:
+      teams:
+        - team-1
+      users:
+        - user-1
 ```
 It has the same parameters as a normal rule:
 -  **name**: Name of the rule. This value must be unique per rule.
@@ -257,6 +262,10 @@ It has the same parameters as a normal rule:
 - **countAuthor**: If the pull request author should be considered as an approval.
 	- If the author belongs to the list of approved users (either by team or by users) his approval will be counted (requiring one less approvals in total).
 	- ** Optional**: Defaults to `false`
+- **excludeAuthor**: If the author belong to one of the teams and/or users in the list, the rule should be skipped.
+	- **Optional**.
+	- This is useful for cases where we want to make sure that some eyes look into a PR, but for we don’t need to ensure that much security on internal teams.
+		- For example, if someone modifies a CI file, we want to make sure they didn’t break anything. Unless it’s someone from the CI team. They *should know* what they are doing.
 #### Other rules
 The other three rules (**or**, **and** and **and-distinct**) have the same configuration, so let’s summarize that here and then move into how they work.
 ```yaml

--- a/src/rules/types.ts
+++ b/src/rules/types.ts
@@ -10,7 +10,7 @@ export type Reviewers = { users?: string[]; teams?: string[]; min_approvals: num
 export interface Rule {
   name: string;
   condition: { include: string[]; exclude?: string[] };
-  greenlightAuthorsFrom?: Omit<Reviewers, "min_approvals">;
+  excludeAuthors?: Omit<Reviewers, "min_approvals">;
   countAuthor?: boolean;
 }
 

--- a/src/rules/types.ts
+++ b/src/rules/types.ts
@@ -10,7 +10,7 @@ export type Reviewers = { users?: string[]; teams?: string[]; min_approvals: num
 export interface Rule {
   name: string;
   condition: { include: string[]; exclude?: string[] };
-  greenlightFrom?: Omit<Reviewers, "min_approvals">;
+  greenlightAuthorsFrom?: Omit<Reviewers, "min_approvals">;
   countAuthor?: boolean;
 }
 

--- a/src/rules/types.ts
+++ b/src/rules/types.ts
@@ -10,6 +10,7 @@ export type Reviewers = { users?: string[]; teams?: string[]; min_approvals: num
 export interface Rule {
   name: string;
   condition: { include: string[]; exclude?: string[] };
+  greenlightFrom?: Omit<Reviewers, "min_approvals">;
   countAuthor?: boolean;
 }
 

--- a/src/rules/types.ts
+++ b/src/rules/types.ts
@@ -10,7 +10,7 @@ export type Reviewers = { users?: string[]; teams?: string[]; min_approvals: num
 export interface Rule {
   name: string;
   condition: { include: string[]; exclude?: string[] };
-  excludeAuthors?: Omit<Reviewers, "min_approvals">;
+  allowedToSkipRule?: Omit<Reviewers, "min_approvals">;
   countAuthor?: boolean;
 }
 

--- a/src/rules/validator.ts
+++ b/src/rules/validator.ts
@@ -24,7 +24,7 @@ const ruleSchema = Joi.object<Rule & { type: string }>().keys({
     include: Joi.array().items(Joi.string()).required(),
     exclude: Joi.array().items(Joi.string()).optional().allow(null),
   }),
-  greenlightFrom:Joi.object<Omit<Reviewers, "min_approvals">>().keys(reviewersObj).optional().or("users", "teams"),
+  greenlightAuthorsFrom:Joi.object<Omit<Reviewers, "min_approvals">>().keys(reviewersObj).optional().or("users", "teams"),
   type: Joi.string().valid(RuleTypes.Basic, RuleTypes.And, RuleTypes.Or, RuleTypes.AndDistinct).required(),
 });
 

--- a/src/rules/validator.ts
+++ b/src/rules/validator.ts
@@ -24,6 +24,7 @@ const ruleSchema = Joi.object<Rule & { type: string }>().keys({
     include: Joi.array().items(Joi.string()).required(),
     exclude: Joi.array().items(Joi.string()).optional().allow(null),
   }),
+  greenlightFrom:Joi.object<Omit<Reviewers, "min_approvals">>().keys(reviewersObj).optional().or("users", "teams"),
   type: Joi.string().valid(RuleTypes.Basic, RuleTypes.And, RuleTypes.Or, RuleTypes.AndDistinct).required(),
 });
 

--- a/src/rules/validator.ts
+++ b/src/rules/validator.ts
@@ -24,10 +24,7 @@ const ruleSchema = Joi.object<Rule & { type: string }>().keys({
     include: Joi.array().items(Joi.string()).required(),
     exclude: Joi.array().items(Joi.string()).optional().allow(null),
   }),
-  greenlightAuthorsFrom: Joi.object<Omit<Reviewers, "min_approvals">>()
-    .keys(reviewersObj)
-    .optional()
-    .or("users", "teams"),
+  excludeAuthors: Joi.object<Omit<Reviewers, "min_approvals">>().keys(reviewersObj).optional().or("users", "teams"),
   type: Joi.string().valid(RuleTypes.Basic, RuleTypes.And, RuleTypes.Or, RuleTypes.AndDistinct).required(),
 });
 

--- a/src/rules/validator.ts
+++ b/src/rules/validator.ts
@@ -24,7 +24,7 @@ const ruleSchema = Joi.object<Rule & { type: string }>().keys({
     include: Joi.array().items(Joi.string()).required(),
     exclude: Joi.array().items(Joi.string()).optional().allow(null),
   }),
-  excludeAuthors: Joi.object<Omit<Reviewers, "min_approvals">>().keys(reviewersObj).optional().or("users", "teams"),
+  allowedToSkipRule: Joi.object<Omit<Reviewers, "min_approvals">>().keys(reviewersObj).optional().or("users", "teams"),
   type: Joi.string().valid(RuleTypes.Basic, RuleTypes.And, RuleTypes.Or, RuleTypes.AndDistinct).required(),
 });
 

--- a/src/rules/validator.ts
+++ b/src/rules/validator.ts
@@ -24,7 +24,10 @@ const ruleSchema = Joi.object<Rule & { type: string }>().keys({
     include: Joi.array().items(Joi.string()).required(),
     exclude: Joi.array().items(Joi.string()).optional().allow(null),
   }),
-  greenlightAuthorsFrom:Joi.object<Omit<Reviewers, "min_approvals">>().keys(reviewersObj).optional().or("users", "teams"),
+  greenlightAuthorsFrom: Joi.object<Omit<Reviewers, "min_approvals">>()
+    .keys(reviewersObj)
+    .optional()
+    .or("users", "teams"),
   type: Joi.string().valid(RuleTypes.Basic, RuleTypes.And, RuleTypes.Or, RuleTypes.AndDistinct).required(),
 });
 

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -81,8 +81,8 @@ export class ActionRunner {
           this.logger.info(`Skipping rule ${rule.name} as no condition matched`);
           // If there are no matches, we simply skip the check
           continue;
-        } else if (rule.greenlightFrom) {
-          const members = await this.fetchAllUsers(rule.greenlightFrom);
+        } else if (rule.greenlightAuthorsFrom) {
+          const members = await this.fetchAllUsers(rule.greenlightAuthorsFrom);
           const author = this.prApi.getAuthor();
           if (members.indexOf(author) > -1) {
             this.logger.info(`Skipping rule ${rule.name} as author belong to greenlight rule.`);

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -375,18 +375,8 @@ export class ActionRunner {
     this.logger.debug(JSON.stringify(rule));
 
     // This is a list of all the users that need to approve a PR
-    let requiredUsers: string[] = [];
-    // If team is set, we fetch the members of such team
-    if (rule.teams) {
-      for (const team of rule.teams) {
-        const members = await this.teamApi.getTeamMembers(team);
-        requiredUsers = concatArraysUniquely(requiredUsers, members);
-      }
-      // If, instead, users are set, we simply push them to the array as we don't need to scan a team
-    }
-    if (rule.users) {
-      requiredUsers = concatArraysUniquely(requiredUsers, rule.users);
-    }
+    const requiredUsers: string[] = await this.fetchAllMembers(rule);
+
     if (requiredUsers.length === 0) {
       throw new Error("No users have been found in the required reviewers");
     }
@@ -462,6 +452,11 @@ export class ActionRunner {
     return matches;
   }
 
+  /**
+   * Fetch all the members of a team and/or list and removes duplicates
+   * @param reviewers Object with users or teams to fetch members
+   * @returns an array with all the users
+   */
   async fetchAllMembers(reviewers: Omit<Reviewers, "min_approvals">): Promise<string[]> {
     const users: Set<string> = new Set<string>();
     if (reviewers.teams) {

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -81,8 +81,8 @@ export class ActionRunner {
           this.logger.info(`Skipping rule ${rule.name} as no condition matched`);
           // If there are no matches, we simply skip the check
           continue;
-        } else if (rule.greenlightAuthorsFrom) {
-          const members = await this.fetchAllUsers(rule.greenlightAuthorsFrom);
+        } else if (rule.excludeAuthors) {
+          const members = await this.fetchAllUsers(rule.excludeAuthors);
           const author = this.prApi.getAuthor();
           if (members.indexOf(author) > -1) {
             this.logger.info(`Skipping rule ${rule.name} as author belong to greenlight rule.`);

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -81,8 +81,8 @@ export class ActionRunner {
           this.logger.info(`Skipping rule ${rule.name} as no condition matched`);
           // If there are no matches, we simply skip the check
           continue;
-        } else if (rule.excludeAuthors) {
-          const members = await this.fetchAllUsers(rule.excludeAuthors);
+        } else if (rule.allowedToSkipRule) {
+          const members = await this.fetchAllUsers(rule.allowedToSkipRule);
           const author = this.prApi.getAuthor();
           if (members.indexOf(author) > -1) {
             this.logger.info(`Skipping rule ${rule.name} as author belong to greenlight rule.`);

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -82,7 +82,7 @@ export class ActionRunner {
           // If there are no matches, we simply skip the check
           continue;
         } else if (rule.greenlightFrom) {
-          const members = await this.fetchAllMembers(rule.greenlightFrom);
+          const members = await this.fetchAllUsers(rule.greenlightFrom);
           const author = this.prApi.getAuthor();
           if (members.indexOf(author) > -1) {
             this.logger.info(`Skipping rule ${rule.name} as author belong to greenlight rule.`);
@@ -375,7 +375,7 @@ export class ActionRunner {
     this.logger.debug(JSON.stringify(rule));
 
     // This is a list of all the users that need to approve a PR
-    const requiredUsers: string[] = await this.fetchAllMembers(rule);
+    const requiredUsers: string[] = await this.fetchAllUsers(rule);
 
     if (requiredUsers.length === 0) {
       throw new Error("No users have been found in the required reviewers");
@@ -457,7 +457,7 @@ export class ActionRunner {
    * @param reviewers Object with users or teams to fetch members
    * @returns an array with all the users
    */
-  async fetchAllMembers(reviewers: Omit<Reviewers, "min_approvals">): Promise<string[]> {
+  async fetchAllUsers(reviewers: Omit<Reviewers, "min_approvals">): Promise<string[]> {
     const users: Set<string> = new Set<string>();
     if (reviewers.teams) {
       for (const team of reviewers.teams) {

--- a/src/test/config.yml
+++ b/src/test/config.yml
@@ -28,7 +28,7 @@ rules:
         - ^polkadot/runtime\/(kusama|polkadot)\/src\/weights\/.+\.rs$
         - ^substrate\/frame\/.+\.md$
     min_approvals: 2
-    greenlightAuthorsFrom:
+    excludeAuthors:
       teams:
         - core-devs
     teams:

--- a/src/test/config.yml
+++ b/src/test/config.yml
@@ -28,7 +28,7 @@ rules:
         - ^polkadot/runtime\/(kusama|polkadot)\/src\/weights\/.+\.rs$
         - ^substrate\/frame\/.+\.md$
     min_approvals: 2
-    excludeAuthors:
+    allowedToSkipRule:
       teams:
         - core-devs
     teams:

--- a/src/test/config.yml
+++ b/src/test/config.yml
@@ -16,6 +16,24 @@ rules:
       - ci
       - release-engineering
 
+  - name: Audit rules
+    type: basic
+    condition:
+      include: 
+        - ^polkadot/runtime\/(kusama|polkadot|common)\/.*
+        - ^polkadot/primitives/src\/.+\.rs$
+        - ^substrate/primitives/.*
+        - ^substrate/frame/.*
+      exclude: 
+        - ^polkadot/runtime\/(kusama|polkadot)\/src\/weights\/.+\.rs$
+        - ^substrate\/frame\/.+\.md$
+    min_approvals: 2
+    greenlightAuthorsFrom:
+      teams:
+        - core-devs
+    teams:
+      - srlabs
+
   - name: Core developers
     countAuthor: true
     condition:

--- a/src/test/rules/config.test.ts
+++ b/src/test/rules/config.test.ts
@@ -272,7 +272,7 @@ describe("Config Parsing", () => {
       expect(config.rules[0].condition.exclude).toBeUndefined();
     });
 
-    describe("excludeAuthor", () => {
+    describe("allowedToSkipRule", () => {
       test("should get teams", async () => {
         api.getConfigFile.mockResolvedValue(`
         rules:

--- a/src/test/rules/config.test.ts
+++ b/src/test/rules/config.test.ts
@@ -271,5 +271,92 @@ describe("Config Parsing", () => {
       const config = await runner.getConfigFile("");
       expect(config.rules[0].condition.exclude).toBeUndefined();
     });
+
+    describe("excludeAuthor", () => {
+      test("should get teams", async () => {
+        api.getConfigFile.mockResolvedValue(`
+        rules:
+          - name: Default review
+            condition:
+              include: 
+                  - '.*'
+              exclude: 
+                  - 'example'
+            type: basic
+            excludeAuthors:
+              teams:
+                - team-example
+            teams:
+              - team-example
+          `);
+        const config = await runner.getConfigFile("");
+        const { excludeAuthors } = config.rules[0];
+        expect(excludeAuthors?.teams).toEqual(["team-example"]);
+        expect(excludeAuthors?.users).toBeUndefined();
+      });
+
+      test("should get users", async () => {
+        api.getConfigFile.mockResolvedValue(`
+        rules:
+          - name: Default review
+            condition:
+              include: 
+                  - '.*'
+              exclude: 
+                  - 'example'
+            type: basic
+            excludeAuthors:
+              users:
+                - user-example
+            teams:
+              - team-example
+          `);
+        const config = await runner.getConfigFile("");
+        const { excludeAuthors } = config.rules[0];
+        expect(excludeAuthors?.users).toEqual(["user-example"]);
+        expect(excludeAuthors?.teams).toBeUndefined();
+      });
+
+      test("should get teams and users", async () => {
+        api.getConfigFile.mockResolvedValue(`
+        rules:
+          - name: Default review
+            condition:
+              include: 
+                  - '.*'
+              exclude: 
+                  - 'example'
+            type: basic
+            excludeAuthors:
+              teams:
+                - team-example
+              users:
+                - user-example
+            teams:
+              - team-example
+          `);
+        const config = await runner.getConfigFile("");
+        const { excludeAuthors } = config.rules[0];
+        expect(excludeAuthors?.teams).toEqual(["team-example"]);
+        expect(excludeAuthors?.users).toEqual(["user-example"]);
+      });
+
+      test("should be null by default", async () => {
+        api.getConfigFile.mockResolvedValue(`
+        rules:
+          - name: Default review
+            condition:
+              include: 
+                  - '.*'
+              exclude: 
+                  - 'example'
+            type: basic
+            teams:
+              - team-example
+          `);
+        const config = await runner.getConfigFile("");
+        expect(config.rules[0].excludeAuthors).toBeUndefined();
+      });
+    });
   });
 });

--- a/src/test/rules/config.test.ts
+++ b/src/test/rules/config.test.ts
@@ -283,16 +283,16 @@ describe("Config Parsing", () => {
               exclude: 
                   - 'example'
             type: basic
-            excludeAuthors:
+            allowedToSkipRule:
               teams:
                 - team-example
             teams:
               - team-example
           `);
         const config = await runner.getConfigFile("");
-        const { excludeAuthors } = config.rules[0];
-        expect(excludeAuthors?.teams).toEqual(["team-example"]);
-        expect(excludeAuthors?.users).toBeUndefined();
+        const { allowedToSkipRule } = config.rules[0];
+        expect(allowedToSkipRule?.teams).toEqual(["team-example"]);
+        expect(allowedToSkipRule?.users).toBeUndefined();
       });
 
       test("should get users", async () => {
@@ -305,16 +305,16 @@ describe("Config Parsing", () => {
               exclude: 
                   - 'example'
             type: basic
-            excludeAuthors:
+            allowedToSkipRule:
               users:
                 - user-example
             teams:
               - team-example
           `);
         const config = await runner.getConfigFile("");
-        const { excludeAuthors } = config.rules[0];
-        expect(excludeAuthors?.users).toEqual(["user-example"]);
-        expect(excludeAuthors?.teams).toBeUndefined();
+        const { allowedToSkipRule } = config.rules[0];
+        expect(allowedToSkipRule?.users).toEqual(["user-example"]);
+        expect(allowedToSkipRule?.teams).toBeUndefined();
       });
 
       test("should get teams and users", async () => {
@@ -327,7 +327,7 @@ describe("Config Parsing", () => {
               exclude: 
                   - 'example'
             type: basic
-            excludeAuthors:
+            allowedToSkipRule:
               teams:
                 - team-example
               users:
@@ -336,9 +336,9 @@ describe("Config Parsing", () => {
               - team-example
           `);
         const config = await runner.getConfigFile("");
-        const { excludeAuthors } = config.rules[0];
-        expect(excludeAuthors?.teams).toEqual(["team-example"]);
-        expect(excludeAuthors?.users).toEqual(["user-example"]);
+        const { allowedToSkipRule } = config.rules[0];
+        expect(allowedToSkipRule?.teams).toEqual(["team-example"]);
+        expect(allowedToSkipRule?.users).toEqual(["user-example"]);
       });
 
       test("should be null by default", async () => {
@@ -355,7 +355,7 @@ describe("Config Parsing", () => {
               - team-example
           `);
         const config = await runner.getConfigFile("");
-        expect(config.rules[0].excludeAuthors).toBeUndefined();
+        expect(config.rules[0].allowedToSkipRule).toBeUndefined();
       });
     });
   });

--- a/src/test/runner/runner.test.ts
+++ b/src/test/runner/runner.test.ts
@@ -32,15 +32,15 @@ describe("Shared validations", () => {
     expect(evaluation).toBeTruthy();
   });
 
-  test("validatePullRequest should return true if author belongs to excludeAuthors", async () => {
+  test("validatePullRequest should return true if author belongs to allowedToSkipRule", async () => {
     const config: ConfigurationFile = {
       rules: [
         {
-          name: "Rule excludeAuthors",
+          name: "Rule allowedToSkipRule",
           type: RuleTypes.Basic,
           condition: { include: ["src"] },
           min_approvals: 1,
-          excludeAuthors: { teams: ["abc"] },
+          allowedToSkipRule: { teams: ["abc"] },
         },
       ],
     };
@@ -49,7 +49,9 @@ describe("Shared validations", () => {
     api.getAuthor.mockReturnValue("user-1");
     const evaluation = await runner.validatePullRequest(config);
     expect(evaluation).toBeTruthy();
-    expect(logger.info).toHaveBeenCalledWith("Skipping rule Rule excludeAuthors as author belong to greenlight rule.");
+    expect(logger.info).toHaveBeenCalledWith(
+      "Skipping rule Rule allowedToSkipRule as author belong to greenlight rule.",
+    );
   });
 
   test("fetchAllUsers should not return duplicates", async () => {

--- a/src/test/runner/runner.test.ts
+++ b/src/test/runner/runner.test.ts
@@ -32,6 +32,24 @@ describe("Shared validations", () => {
     expect(evaluation).toBeTruthy();
   });
 
+  test("validatePullRequest should return true if no rule matches any files", async () => {
+    const config: ConfigurationFile = {
+      rules: [
+        { name: "Rule 1", type: RuleTypes.Basic, condition: { include: ["src"] }, min_approvals: 1 },
+        { name: "Rule 2", type: RuleTypes.Basic, condition: { include: ["README.md"] }, min_approvals: 99 },
+      ],
+    };
+    api.listModifiedFiles.mockResolvedValue([".github/workflows/review-bot.yml", "LICENSE"]);
+    const evaluation = await runner.validatePullRequest(config);
+    expect(evaluation).toBeTruthy();
+  });
+
+  test("fetchAllUsers should not return duplicates", async () => {
+    teamsApi.getTeamMembers.mockResolvedValue(["user-1", "user-2", "user-3"]);
+    const users = await runner.fetchAllUsers({ teams: ["abc"], users: ["user-1", "user-2", "user-4"] });
+    expect(users).toStrictEqual(["user-1", "user-2", "user-3", "user-4"]);
+  });
+
   describe("listFilesThatMatchRuleCondition tests", () => {
     test("should get values that match the condition", () => {
       const mockRule = { condition: { include: ["src"] } };


### PR DESCRIPTION
This adds the feature to exclude rules from being executed when the author belongs to a particular team or list. 
This resolves #66.