### PR TITLE
Fixed duplicated usernames in and-distinct error object

### DIFF
--- a/src/runner.ts
+++ b/src/runner.ts
@@ -269,7 +269,7 @@ export class ActionRunner {
     // Utility method used to generate error
     const generateErrorReport = (): ReviewReport => {
       const filterMissingUsers = (reviewData: { users?: string[] }[]): string[] =>
-        reviewData.flatMap((r) => r.users ?? []).filter((u) => approvals.indexOf(u) < 0);
+        Array.from(new Set(reviewData.flatMap((r) => r.users ?? []).filter((u) => approvals.indexOf(u) < 0)));
 
       // Calculating all the possible combinations to see the missing reviewers is very complicated
       // Instead we request everyone who hasn't reviewed yet

--- a/src/test/runner/validation/andDistinct.test.ts
+++ b/src/test/runner/validation/andDistinct.test.ts
@@ -117,6 +117,23 @@ describe("'And distinct' rule validation", () => {
       expect(logger.warn).toHaveBeenCalledWith("Not enough positive reviews to match a subcondition");
     });
 
+    test("should not have duplicates in missingUsers", async () => {
+      const rule: AndDistinctRule = {
+        type: RuleTypes.AndDistinct,
+        reviewers: [
+          { users: [users[0], "def"], min_approvals: 2 },
+          { teams: ["team-abc"], min_approvals: 1 },
+        ],
+        name: "test",
+        condition: { include: [] },
+      };
+
+      const [result, error] = await runner.andDistinctEvaluation(rule);
+      expect(result).toBe(false);
+      const hasDuplicates = <T>(arr: T[]) => arr.some((item, index) => arr.indexOf(item) !== index);
+      expect(hasDuplicates(error?.missingUsers as string[])).toBeFalsy();
+    });
+
     test("should not consider author in evaluation", async () => {
       const rule: AndDistinctRule = {
         type: RuleTypes.AndDistinct,


### PR DESCRIPTION
Found a bug where usernames where duplicated in the error object.

This fixes #73

