### PR TITLE
Added more debug log verbosity

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -26,4 +26,4 @@ outputs:
 
 runs:
   using: 'docker'
-  image: 'docker://ghcr.io/paritytech/review-bot/action:1.0.0'
+  image: 'docker://ghcr.io/paritytech/review-bot/action:1.0.1'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "review-bot",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Have custom review rules for PRs with auto assignment",
   "main": "src/index.ts",
   "scripts": {

--- a/src/github/pullRequest.ts
+++ b/src/github/pullRequest.ts
@@ -96,14 +96,16 @@ export class PullRequestApi {
       const approvals = latestReviews.filter((review) => caseInsensitiveEqual(review.state, "approved"));
       this.usersThatApprovedThePr = approvals.map((approval) => approval.user.login);
     }
-    this.logger.debug(`PR approvals are ${JSON.stringify(this.usersThatApprovedThePr)}`);
+
+    const approvals = this.usersThatApprovedThePr;
 
     if (countAuthor) {
-      // If this value is true, we add the author to the list of approvals
-      return [...this.usersThatApprovedThePr, this.pr.user.login];
+      this.logger.info("Counting author in list of approvals");
+      approvals.push(this.pr.user.login);
     }
+    this.logger.debug(`PR approvals are ${JSON.stringify(approvals)}`);
 
-    return this.usersThatApprovedThePr;
+    return approvals;
   }
 
   /** Returns the login of the PR's author */

--- a/src/github/teams.ts
+++ b/src/github/teams.ts
@@ -25,7 +25,7 @@ export class GitHubTeamsApi implements TeamApi {
     private readonly api: GitHubClient,
     private readonly org: string,
     private readonly logger: ActionLogger,
-  ) { }
+  ) {}
 
   async getTeamMembers(teamName: string): Promise<string[]> {
     // We first verify that this information hasn't been fetched yet

--- a/src/github/teams.ts
+++ b/src/github/teams.ts
@@ -25,7 +25,7 @@ export class GitHubTeamsApi implements TeamApi {
     private readonly api: GitHubClient,
     private readonly org: string,
     private readonly logger: ActionLogger,
-  ) {}
+  ) { }
 
   async getTeamMembers(teamName: string): Promise<string[]> {
     // We first verify that this information hasn't been fetched yet
@@ -33,6 +33,7 @@ export class GitHubTeamsApi implements TeamApi {
       this.logger.debug(`Fetching team '${teamName}'`);
       const { data } = await this.api.rest.teams.listMembersInOrg({ org: this.org, team_slug: teamName });
       const members = data.map((d) => d.login);
+      this.logger.debug(`Members are ${JSON.stringify(members)}`);
       this.teamsCache.set(teamName, members);
     }
     return this.teamsCache.get(teamName) as string[];


### PR DESCRIPTION
Added more logs when fetching approvals and team members.

Removed a left over log

Now the debug logs will count the author and will show the team members (debug logs can only be seen by people who have access to trigger the actions)

Resolves #74

Updated version to `1.0.1`