### PR TITLE
fixed duplicated approvals

### DIFF
--- a/src/github/pullRequest.ts
+++ b/src/github/pullRequest.ts
@@ -97,11 +97,11 @@ export class PullRequestApi {
       this.usersThatApprovedThePr = approvals.map((approval) => approval.user.login);
     }
 
-    const approvals = this.usersThatApprovedThePr;
+    let approvals = this.usersThatApprovedThePr;
 
     if (countAuthor) {
       this.logger.info("Counting author in list of approvals");
-      approvals.push(this.pr.user.login);
+      approvals = [this.pr.user.login, ...approvals];
     }
     this.logger.debug(`PR approvals are ${JSON.stringify(approvals)}`);
 


### PR DESCRIPTION
This was generated because, when pushing a new value into the array, it had the same reference to the cached array so it was modifying that one.

This closes #77