### PR TITLE
Added better rank report and testing

### DIFF
--- a/src/runner.ts
+++ b/src/runner.ts
@@ -41,7 +41,7 @@ export class ActionRunner {
     private readonly polkadotApi: TeamApi,
     private readonly checks: GitHubChecksApi,
     private readonly logger: ActionLogger,
-  ) { }
+  ) {}
 
   /**
    * Fetches the configuration file, parses it and validates it.
@@ -521,7 +521,7 @@ const getRequiredRanks = (reports: Pick<ReviewReport, "missingRank">[]): number[
   } else {
     return undefined;
   }
-}
+};
 
 const unifyReport = (reports: ReviewReport[], name: string): RuleReport => {
   const ranks = getRequiredRanks(reports);

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -251,14 +251,8 @@ export class ActionRunner {
     const requirements: { users: string[]; requiredApprovals: number }[] = [];
     // We get all the users belonging to each 'and distinct' review condition
     for (const reviewers of rule.reviewers) {
-      let usersToAdd: string[] = reviewers.users ?? [];
-      if (reviewers.teams) {
-        for (const team of reviewers.teams) {
-          const members = await this.teamApi.getTeamMembers(team);
-          usersToAdd = [...new Set([...usersToAdd, ...members])];
-        }
-      }
-      requirements.push({ users: usersToAdd, requiredApprovals: reviewers.min_approvals });
+      const users = await this.fetchAllUsers(reviewers);
+      requirements.push({ users, requiredApprovals: reviewers.min_approvals });
     }
 
     // We count how many reviews are needed in total

--- a/src/test/runner/conditions.test.ts
+++ b/src/test/runner/conditions.test.ts
@@ -164,6 +164,7 @@ describe("evaluateCondition tests", () => {
       expect(report?.missingUsers).toEqual(["user-1"]);
       expect(report?.teamsToRequest).toBeUndefined();
       expect(report?.usersToRequest).toBeUndefined();
+      expect(report?.missingRank).toBe(3);
     });
 
     test("should pass with required rank users", async () => {

--- a/src/test/runner/conditions.test.ts
+++ b/src/test/runner/conditions.test.ts
@@ -8,11 +8,14 @@ import { ActionRunner } from "../../runner";
 describe("evaluateCondition tests", () => {
   let api: MockProxy<PullRequestApi>;
   let teamsApi: MockProxy<TeamApi>;
+  let fellowsApi: MockProxy<TeamApi>;
+
   let runner: ActionRunner;
   beforeEach(() => {
     api = mock<PullRequestApi>();
     teamsApi = mock<TeamApi>();
-    runner = new ActionRunner(api, teamsApi, mock<TeamApi>(), mock<GitHubChecksApi>(), mock<ActionLogger>());
+    fellowsApi = mock<TeamApi>();
+    runner = new ActionRunner(api, teamsApi, fellowsApi, mock<GitHubChecksApi>(), mock<ActionLogger>());
   });
 
   test("should throw if no teams or users were set", async () => {
@@ -146,6 +149,32 @@ describe("evaluateCondition tests", () => {
           expect(report?.usersToRequest).toEqual([users[0]]);
         });
       });
+    });
+  });
+  describe("rank tests", () => {
+    test("should require rank users", async () => {
+      fellowsApi.getTeamMembers.mockResolvedValue(["user-1"]);
+      api.listApprovedReviewsAuthors.mockResolvedValue([]);
+      const [result, report] = await runner.evaluateCondition({
+        min_approvals: 1,
+        minFellowsRank: 3,
+      });
+
+      expect(result).toBeFalsy();
+      expect(report?.missingUsers).toEqual(["user-1"]);
+      expect(report?.teamsToRequest).toBeUndefined();
+      expect(report?.usersToRequest).toBeUndefined();
+    });
+
+    test("should pass with required rank users", async () => {
+      fellowsApi.getTeamMembers.mockResolvedValue(["user-1"]);
+      api.listApprovedReviewsAuthors.mockResolvedValue(["user-1"]);
+      const [result] = await runner.evaluateCondition({
+        min_approvals: 1,
+        minFellowsRank: 3,
+      });
+
+      expect(result).toBeTruthy();
     });
   });
 });

--- a/src/test/runner/validation/or.test.ts
+++ b/src/test/runner/validation/or.test.ts
@@ -9,15 +9,17 @@ import { ActionRunner } from "../../../runner";
 describe("'Or' rule validation", () => {
   let api: MockProxy<PullRequestApi>;
   let teamsApi: MockProxy<TeamApi>;
+  let fellowsApi: MockProxy<TeamApi>;
   let runner: ActionRunner;
   const users = ["user-1", "user-2", "user-3"];
   beforeEach(() => {
     api = mock<PullRequestApi>();
     teamsApi = mock<TeamApi>();
+    fellowsApi = mock<TeamApi>();
     teamsApi.getTeamMembers.calledWith("abc").mockResolvedValue(users);
     api.listModifiedFiles.mockResolvedValue([".github/workflows/review-bot.yml"]);
     api.listApprovedReviewsAuthors.mockResolvedValue([]);
-    runner = new ActionRunner(api, teamsApi, mock<TeamApi>(), mock<GitHubChecksApi>(), mock<ActionLogger>());
+    runner = new ActionRunner(api, teamsApi, fellowsApi, mock<GitHubChecksApi>(), mock<ActionLogger>());
   });
 
   describe("approvals", () => {
@@ -75,7 +77,27 @@ describe("'Or' rule validation", () => {
       const { reports } = await runner.validatePullRequest(config);
       expect(reports).toHaveLength(0);
     });
+
+    test("should accept lowest rank for both cases", async () => {
+      fellowsApi.getTeamMembers.calledWith("1").mockResolvedValue(users);
+      fellowsApi.getTeamMembers.calledWith("2").mockResolvedValue([users[2]]);
+      api.listApprovedReviewsAuthors.mockResolvedValue([users[0]]);
+      const { reports } = await runner.validatePullRequest({
+        rules: [
+          {
+            name: "Or rule",
+            type: RuleTypes.Or,
+            condition: { include: ["review-bot.yml"] },
+            reviewers: [
+              { minFellowsRank: 1, min_approvals: 1 },
+              { minFellowsRank: 2, min_approvals: 1 },
+            ],
+          },
+        ],
+      }); expect(reports).toHaveLength(0);
+    });
   });
+
   describe("errors", () => {
     test("should report all missing individual users if all of the rules have not been met", async () => {
       const individualUsers = [users[0], users[1]];
@@ -122,6 +144,27 @@ describe("'Or' rule validation", () => {
       const { reports } = await runner.validatePullRequest(config);
       const [result] = reports;
       expect(result.missingReviews).toEqual(1);
+    });
+
+    test("should request lowest rank", async () => {
+      fellowsApi.getTeamMembers.mockResolvedValue([users[2]]);
+      const { reports } = await runner.validatePullRequest({
+        rules: [
+          {
+            name: "Or rule",
+            type: RuleTypes.Or,
+            condition: { include: ["review-bot.yml"] },
+            reviewers: [
+              { minFellowsRank: 1, min_approvals: 1 },
+              { minFellowsRank: 2, min_approvals: 1 },
+            ],
+          },
+        ],
+      });
+      const [result] = reports;
+      expect(result.missingReviews).toEqual(1);
+      expect(result.missingUsers).toEqual([users[2]]);
+      expect(result.missingRank).toEqual(1);
     });
   });
 });

--- a/src/test/runner/validation/or.test.ts
+++ b/src/test/runner/validation/or.test.ts
@@ -94,7 +94,8 @@ describe("'Or' rule validation", () => {
             ],
           },
         ],
-      }); expect(reports).toHaveLength(0);
+      });
+      expect(reports).toHaveLength(0);
     });
   });
 


### PR DESCRIPTION
Enhanced the check report, adding the information of the missing rank. This resolves #80 

Added tests that evaluate the ranking system, and how it applies the rules. This resolves #81

For the `or` rule, we request the lowest required rank, and for the `and` rule we request the highest rank.

In the case of `and-distinct` we request the highest rank.