### PR TITLE
Fixed bug where only 30 members where shown

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -26,4 +26,4 @@ outputs:
 
 runs:
   using: 'docker'
-  image: 'docker://ghcr.io/paritytech/review-bot/action:2.0.0'
+  image: 'docker://ghcr.io/paritytech/review-bot/action:2.0.1'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "review-bot",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Have custom review rules for PRs with auto assignment",
   "main": "src/index.ts",
   "scripts": {

--- a/src/github/teams.ts
+++ b/src/github/teams.ts
@@ -22,8 +22,12 @@ export class GitHubTeamsApi implements TeamApi {
     // We first verify that this information hasn't been fetched yet
     if (!this.teamsCache.has(teamName)) {
       this.logger.debug(`Fetching team '${teamName}'`);
-      const { data } = await this.api.rest.teams.listMembersInOrg({ org: this.org, team_slug: teamName });
-      const members = data.map((d) => d.login);
+
+      const membersRequest = await this.api.paginate(this.api.rest.teams.listMembersInOrg, {
+        org: this.org,
+        team_slug: teamName,
+      });
+      const members = membersRequest.map((m) => m.login);
       this.logger.debug(`Members are ${JSON.stringify(members)}`);
       this.teamsCache.set(teamName, members);
     }


### PR DESCRIPTION
Fixed a pagination issue where the system was only obtaining the first 30 membes of a team.

By adding the [pagination method of Octokit](https://actions-cool.github.io/octokit-rest/guide/05_pagination/) we can obtain all of the results at once.

Updated project version to 2.0.1 to generate a new release.

This fixes #88