### PR TITLE
Implement request reviewers on itself

### DIFF
--- a/.github/workflows/review-bot.yml
+++ b/.github/workflows/review-bot.yml
@@ -30,3 +30,4 @@ jobs:
           team-token: ${{ steps.team_token.outputs.token }}
           checks-token: ${{ steps.team_token.outputs.token }}
           pr-number: ${{ steps.number.outputs.content }}
+          request-reviewers: true

--- a/.github/workflows/review-bot.yml
+++ b/.github/workflows/review-bot.yml
@@ -6,10 +6,6 @@ on:
     types:
       - completed
 
-permissions:
-  contents: read
-  checks: write
-
 jobs:
   review-approvals:
     runs-on: ubuntu-latest
@@ -30,7 +26,7 @@ jobs:
       - name: "Evaluates PR reviews and assigns reviewers"
         uses: paritytech/review-bot@main
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ steps.team_token.outputs.token }}
           team-token: ${{ steps.team_token.outputs.token }}
           checks-token: ${{ steps.team_token.outputs.token }}
           pr-number: ${{ steps.number.outputs.content }}

--- a/README.md
+++ b/README.md
@@ -441,7 +441,9 @@ It also has any other field from the [`basic rule`](#basic-rule) (with the excep
 	- **Required**
 
 ##### Note
-The fellows rule will never request reviewers, even if `request-reviewers` rule is enabled.
+The fellows rule will never request reviewers, even if `request-reviewers` rule is enabled. 
+
+This is because there are ~50 fellows and GitHub’s PR request limit is 20 users, so, if a low rank is required, the system wouldn’t allow to assign them.
 
 ### Evaluating config
 


### PR DESCRIPTION
This PR has three changes:

1. Updated the README file to be more detailed on how to properly install the app with the request reviewers feature.
2. Updated the `repo-token` field to use the GitHub app which now has `pull-request` write permissions.
3. Enabled `request-reviewers` (won't trigger on this PR until it is merged).