### PR TITLE
Added more details in the rule output

### DIFF
--- a/src/runner.ts
+++ b/src/runner.ts
@@ -277,11 +277,11 @@ export class ActionRunner {
         .emptyBuffer()
         .addHeading(report.name, 2)
         .addHeading(`Missing ${report.missingReviews} review${report.missingReviews > 1 ? "s" : ""}`, 4)
-        .addHeading("Rule explanation", 5)
-        .addRaw(ruleExplanation(report.type))
-        .addEOL()
-        .addRaw(
-          "For more info found out how the rules work in [Review-bot types](https://github.com/paritytech/review-bot#types)",
+        .addDetails(
+          "Rule explanation",
+          `${ruleExplanation(
+            report.type,
+          )}\n\nFor more info found out how the rules work in [Review-bot types](https://github.com/paritytech/review-bot#types)`,
         );
       if (report.usersToRequest && report.usersToRequest.length > 0) {
         text = text

--- a/src/test/runner/runner.test.ts
+++ b/src/test/runner/runner.test.ts
@@ -5,7 +5,7 @@ import { GitHubChecksApi } from "../../github/check";
 import { PullRequestApi } from "../../github/pullRequest";
 import { ActionLogger, TeamApi } from "../../github/types";
 import { ConfigurationFile, Rule, RuleTypes } from "../../rules/types";
-import { ActionRunner } from "../../runner";
+import { ActionRunner, RuleReport } from "../../runner";
 
 describe("Shared validations", () => {
   let api: MockProxy<PullRequestApi>;
@@ -94,12 +94,14 @@ describe("Shared validations", () => {
   });
 
   describe("Validation in requestReviewers", () => {
-    const exampleReport = {
+    const exampleReport: RuleReport = {
       name: "Example",
       missingUsers: ["user-1", "user-2", "user-3"],
       missingReviews: 2,
       teamsToRequest: ["team-1"],
       usersToRequest: ["user-1"],
+      type: RuleTypes.Basic,
+      countingReviews: [],
     };
 
     test("should request reviewers if object is not defined", async () => {


### PR DESCRIPTION
Added detailed explanation in the rules output, informing how each rule works and a list of approvals that counts towards incomplete rules (so we can see who's review count where).

Resolves #103

---

Example of rule output:

Details per rule:

## Core developers

#### Missing 1 review

<details><summary>Rule explanation</summary>Rule 'Basic' requires a given amount of reviews from users/teams 

For more info found out how the rules work in [Review-bot types](https://github.com/paritytech/review-bot#types)</details>

### Missing reviews from teams

*   core-devs

### Users approvals that counted towards this rule

*   gavofyork

## Runtime files cumulus

#### Missing 2 reviews

<details><summary>Rule explanation</summary>Rule 'And Distinct' has many required reviewers/teams and requires all of them to be fulfilled **by different users**. 

The approval of one user that belongs to _two teams_ will count only towards one team. 

For more info found out how the rules work in [Review-bot types](https://github.com/paritytech/review-bot#types)</details>

### Missing reviews from teams

*   locks-review
*   polkadot-review

### Users approvals that counted towards this rule

*   gavofyork