### PR TITLE
Fellows: Added search of super identity

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -32,4 +32,4 @@ outputs:
 
 runs:
   using: 'docker'
-  image: 'docker://ghcr.io/paritytech/review-bot/action:2.3.0'
+  image: 'docker://ghcr.io/paritytech/review-bot/action:2.3.1'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "review-bot",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Have custom review rules for PRs with auto assignment",
   "main": "src/index.ts",
   "scripts": {


### PR DESCRIPTION
Added logic to search for a super identity in case that the user does not have an identity. 

If a super identity is found, this will be added to the array of address to fetch an identity from.

This fixes https://github.com/paritytech/review-bot/issues/107

Updated version to `2.3.1` as this is a small patch.