### PR TITLE
Upgraded dependencies of actions

### DIFF
--- a/.github/workflows/github-issue-sync.yml
+++ b/.github/workflows/github-issue-sync.yml
@@ -18,12 +18,12 @@ jobs:
     steps:
       - name: Generate token
         id: generate_token
-        uses: tibdex/github-app-token@v1
+        uses: actions/create-github-app-token@v1.9.3
         with:
-          app_id: ${{ secrets.PROJECT_APP_ID }}
-          private_key: ${{ secrets.PROJECT_APP_KEY }}
+          app-id: ${{ secrets.PROJECT_APP_ID }}
+          private-key: ${{ secrets.PROJECT_APP_KEY }}
       - name: Sync issues
-        uses: paritytech/github-issue-sync@v0.3
+        uses: paritytech/github-issue-sync@v0.3.2
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PROJECT_TOKEN: ${{ steps.generate_token.outputs.token }}

--- a/.github/workflows/javascript-test.yml
+++ b/.github/workflows/javascript-test.yml
@@ -3,55 +3,35 @@ name: Continuous testing
 on: [pull_request]
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Use node 20
-        uses: actions/setup-node@v3
-        with:
-          node-version: 20
-      - uses: c-hive/gha-yarn-cache@v2
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile
-      - run: yarn run lint
-
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Use node 20
-        uses: actions/setup-node@v3
-        with:
-          node-version: 20
-      - uses: c-hive/gha-yarn-cache@v2
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile
-      - run: yarn run build
-
   test:
+    strategy:
+      matrix:
+        command: [lint, build, test, "cli '.github/review-bot.yml'"]
     runs-on: ubuntu-latest
+    name: running ${{ matrix.command }}
+    timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v3
-      - name: Use node 20
-        uses: actions/setup-node@v3
+      - uses: actions/checkout@v4.1.3
+      - uses: actions/setup-node@v4.0.2
         with:
           node-version: 20
-      - uses: c-hive/gha-yarn-cache@v2
+      - name: Cache node modules
+        id: cache-npm
+        uses: actions/cache@v4.0.2
+        env:
+          cache-name: cache-node-modules
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: ${{ runner.os }}-build-${{ env.cache-name }}-
       - name: Install dependencies
         run: yarn install --frozen-lockfile
-      - run: yarn run test
+      - run: yarn run ${{ matrix.command }}
 
-  evaluate-config:
+  conclude:
     runs-on: ubuntu-latest
+    name: All tests passed
+    needs: [test]
     steps:
-      - uses: actions/checkout@v3
-      - name: Use node 20
-        uses: actions/setup-node@v3
-        with:
-          node-version: 20
-      - uses: c-hive/gha-yarn-cache@v2
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile
-      - name: Evaluates config file
-        run: yarn run cli ".github/review-bot.yml"
+      - run: echo '### Good job! All the tests passed 🚀' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           version: ${{ steps.package_version.outputs.VERSION }}
         # Verifies if there is a tag with that version number
-      - uses: mukunku/tag-exists-action@v1.4.0
+      - uses: mukunku/tag-exists-action@v1.6.0
         if: steps.verification.outputs.VERSION
         id: checkTag
         with: 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,14 +13,14 @@ jobs:
   test-image:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3.3.0
+      - uses: actions/checkout@v4.1.3
       - name: Check that the image builds
         run: docker build . --file Dockerfile
   validate-action:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@v3.3.0
+      - uses: actions/checkout@v4.1.3
       # This checks that .github/workflows/review-bot.yml is pointing towards the main branch
       # as, during development, we change this to use the code from the test branch and
       # we may forget to set it back to main
@@ -43,7 +43,7 @@ jobs:
       version: ${{ steps.verification.outputs.VERSION }}
       exists: ${{ steps.checkTag.outputs.exists }}
     steps:
-      - uses: actions/checkout@v3.3.0
+      - uses: actions/checkout@v4.1.3
       - name: Extract package.json version
         id: package_version
         run: echo "VERSION=$(jq '.version' -r package.json)" >> $GITHUB_OUTPUT
@@ -68,14 +68,14 @@ jobs:
       contents: write
       packages: write
     steps:
-      - uses: actions/checkout@v3.3.0
+      - uses: actions/checkout@v4.1.3
       - name: Tag version and create release
         run: gh release create $VERSION --generate-notes
         env:
           VERSION: v${{ needs.compare-versions.outputs.version }}
           GH_TOKEN: ${{ github.token }}
       - name: Log in to the Container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v3.1.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -86,9 +86,9 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository }}/${{ env.IMAGE_NAME }}
           tags: ${{ needs.compare-versions.outputs.version }}
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4.1.3
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v5.3.0
         with:
           context: .
           push: true

--- a/.github/workflows/review-bot.yml
+++ b/.github/workflows/review-bot.yml
@@ -17,10 +17,10 @@ jobs:
           artifact-name: pr_number
       - name: Generate token
         id: team_token
-        uses: tibdex/github-app-token@v1
+        uses: actions/create-github-app-token@v1.9.3
         with:
-          app_id: ${{ secrets.REVIEW_APP_ID }}
-          private_key: ${{ secrets.REVIEW_APP_KEY }}
+          app-id: ${{ secrets.REVIEW_APP_ID }}
+          private-key: ${{ secrets.REVIEW_APP_KEY }}
       # !This must always point to main. 
       # Change it for the PRs but remember to change it back
       - name: "Evaluates PR reviews and assigns reviewers"

--- a/README.md
+++ b/README.md
@@ -178,10 +178,10 @@ Because this project is intended to be used with a token, we need to do an extra
     steps:
       - name: Generate token
         id: generate_token
-        uses: tibdex/github-app-token@v1
+        uses: actions/create-github-app-token@v1.9.3
         with:
-          app_id: ${{ secrets.APP_ID }}
-          private_key: ${{ secrets.PRIVATE_KEY }}
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.PRIVATE_KEY }}
       - name: "Evaluates PR reviews"
         uses: paritytech/review-bot@main
         with:


### PR DESCRIPTION
- Upgraded all actions to their latest versions
  - No more `node 16 not supported` warnings
- Converted tests jobs into matrix
  - It's more straightforward as it has a final job
- Updated `tibdex/github-app-token` to `actions/create-github-app-token`
  - Done both in the docs as in the actions themselves.